### PR TITLE
Fix/Do not display non-empty result warning for value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Implemented the `#arity` method, which returns an indication of the number of ar
 
 Refactored internal logic for returning result objects.
 
+Fixed a bug causing an erroneous warning to be displayed when `#process` discards an old result with a value.
+
 ## 0.6.0
 
 The "By Your Command" Update.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,6 +15,7 @@
 - Command#to_proc
 - :clear_errors => true option on #chain
 - #context object
+- command currying
 
 #### Cuprum::DSL
 

--- a/lib/cuprum/processing.rb
+++ b/lib/cuprum/processing.rb
@@ -128,9 +128,7 @@ module Cuprum
       if value_is_result?(other)
         return result if result == other
 
-        if result.respond_to?(:empty?) && !result.empty?
-          Cuprum.warn(Cuprum::Utils::ResultNotEmptyWarning.new(result).message)
-        end # if
+        warn_unless_empty!(result)
 
         other.to_result
       else
@@ -176,5 +174,13 @@ module Cuprum
     def value_is_result? value
       VALUE_METHODS.all? { |method_name| value.respond_to?(method_name) }
     end # method value
+
+    def warn_unless_empty! result
+      return unless result.respond_to?(:empty?) && !result.empty?
+
+      not_empty = Cuprum::Utils::ResultNotEmptyWarning.new(result)
+
+      Cuprum.warn(not_empty.message) if not_empty.warning?
+    end # method warn_unless_empty!
   end # module
 end # module

--- a/lib/cuprum/utils/result_not_empty_warning.rb
+++ b/lib/cuprum/utils/result_not_empty_warning.rb
@@ -16,9 +16,15 @@ module Cuprum::Utils
 
     # @return [String] The warning message for the given result.
     def message
-      # byebug
+      return ''.freeze if warnings.empty?
+
       MESSAGE + humanize_list(warnings).freeze
     end # method message
+
+    # @return [Boolean] True if a warning is generated, otherwise false.
+    def warning?
+      !warnings.empty?
+    end # method warning?
 
     private
 
@@ -55,11 +61,12 @@ module Cuprum::Utils
     end # method status_set_warning
 
     def warnings
-      [
-        errors_not_empty_warning,
-        status_set_warning,
-        halted_warning
-      ].compact
+      @warnings ||=
+        [
+          errors_not_empty_warning,
+          status_set_warning,
+          halted_warning
+        ].compact
     end # method warnings
   end # class
 end # module

--- a/spec/cuprum/utils/result_not_empty_warning_spec.rb
+++ b/spec/cuprum/utils/result_not_empty_warning_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe Cuprum::Utils::ResultNotEmptyWarning do
   describe '#message' do
     let(:expected) { '#process returned a result, but ' }
 
-    include_examples 'should have reader', :message
+    include_examples 'should have reader', :message, ''
+
+    describe 'when the result has a value' do
+      let(:value) { Object.new }
+
+      it { expect(instance.message).to be == '' }
+    end # describe
 
     describe 'when the result has errors' do
       let(:errors) { ['errors.messages.unknown'] }
@@ -66,6 +72,48 @@ RSpec.describe Cuprum::Utils::ResultNotEmptyWarning do
       end # let
 
       it { expect(instance.message).to be == expected }
+    end # describe
+  end # describe
+
+  describe '#warning?' do
+    include_examples 'should have predicate', :warning?, false
+
+    describe 'when the result has a value' do
+      let(:value) { Object.new }
+
+      it { expect(instance.warning?).to be false }
+    end # describe
+
+    describe 'when the result has errors' do
+      let(:errors) { ['errors.messages.unknown'] }
+
+      it { expect(instance.warning?).to be true }
+    end # describe
+
+    describe 'when the result status is set' do
+      let(:result) { super().failure! }
+
+      it { expect(instance.warning?).to be true }
+    end # describe
+
+    describe 'when the result is halted' do
+      let(:result) { super().halt! }
+
+      it { expect(instance.warning?).to be true }
+    end # describe
+
+    describe 'when the result has errors and a set status' do
+      let(:errors) { ['errors.messages.unknown'] }
+      let(:result) { super().success! }
+
+      it { expect(instance.warning?).to be true }
+    end # describe
+
+    describe 'when the result has errors, a set status, and is halted' do
+      let(:errors) { ['errors.messages.unknown'] }
+      let(:result) { super().success!.halt! }
+
+      it { expect(instance.warning?).to be true }
     end # describe
   end # describe
 end # describe


### PR DESCRIPTION
When #process returns a different result, and the old result has a value but no errors, status or is halted, do not display a warning.