### PR TITLE
Chore/Address RuboCop violations.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
+  NewCops: enable
   Include:
     - 'lib/**/*.rb'
     - 'spec/**/*.rb'
@@ -9,16 +10,19 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
-Layout/AlignParameters:
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+
+Layout/LineLength:
+  Max: 80
+
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
   IndentationWidth: ~
-
-Layout/DotPosition:
-  # Disabled while transitioning to modern syntax.
-  Enabled: false
-
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
 
 Metrics/BlockLength:
   Exclude:
@@ -28,10 +32,9 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*.rb'
 
-Performance/RedundantBlockCall:
-  # Incompatible with documentation/testing requirement of explicitly defining
-  # a block argument.
-  Enabled: false
+Naming/FileName:
+  Exclude:
+    - Gemfile
 
 RSpec/ExampleLength:
   Max: 10
@@ -42,8 +45,11 @@ RSpec/ExampleWording:
 RSpec/HookArgument:
   EnforcedStyle: example
 
-RSpec/MultipleExpectations:
-  Enabled: false
+RSpec/LeadingSubject:
+  Enabled: false # Expects subject to precede shared examples.
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
 
 RSpec/RepeatedDescription:
   # Does not recognize :wrap_context nodes.
@@ -64,22 +70,6 @@ Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/DoubleNegation:
-  Enabled: false
-
-Style/FileName:
-  Exclude:
-    - Gemfile
-
-Style/FrozenStringLiteralComment:
-  # Incompatible with file location comments.
-  Enabled: false
-
-Style/HashSyntax:
-  # Disabled while transitioning to modern syntax.
-  Enabled: false
-
-Style/MethodDefParentheses:
-  # Disabled while transitioning to modern syntax.
   Enabled: false
 
 Style/MultilineBlockChain:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## 0.10
+## 1.0.0
+
+The "Look On My Works, Ye Mighty, and Despair" Update
+
+### Commands
+
+Removed the deprecated chaining mechanic.
+
+#### Steps
+
+The error type and message when calling `#steps` without a block has changed.
+
+## 0.10.0
 
 The "One Small Step" Update
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'rspec-sleeping_king_studios', '~> 2.5'
 
 gem 'sleeping_king_studios-tasks',
   git: 'https://github.com/sleepingkingstudios/sleeping_king_studios-tasks'
@@ -11,4 +11,4 @@ group :development, :test do
   gem 'byebug', '~> 9.0', '>= 9.0.6'
 end
 
-gem 'yard', '~> 0.9', '>= 0.9.9', :require => false, :group => :doc
+gem 'yard', '~> 0.9', '>= 0.9.9', require: false, group: :doc

--- a/cuprum.gemspec
+++ b/cuprum.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH << './lib'
 
 require 'cuprum/version'
@@ -8,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.date        = Time.now.utc.strftime '%Y-%m-%d'
   gem.summary     = 'An opinionated implementation of the Command pattern.'
 
-  description = <<-DESCRIPTION
+  description = <<~DESCRIPTION
     An opinionated implementation of the Command pattern for Ruby applications.
     Cuprum wraps your business logic in a consistent, object-oriented interface
     and features status and error management, composability and control flow
@@ -20,14 +22,15 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'http://sleepingkingstudios.com'
   gem.license     = 'MIT'
 
+  gem.required_ruby_version = '>= 2.5.0'
   gem.require_path = 'lib'
   gem.files        = Dir['lib/**/*.rb', 'LICENSE', '*.md']
 
   gem.add_runtime_dependency 'sleeping_king_studios-tools', '~> 0.8'
 
-  gem.add_development_dependency 'rspec',                       '~> 3.6'
-  gem.add_development_dependency 'rspec-sleeping_king_studios', '~> 2.3'
-  gem.add_development_dependency 'rubocop',                     '~> 0.49.1'
-  gem.add_development_dependency 'rubocop-rspec',               '~> 1.15'
+  gem.add_development_dependency 'rspec',                       '~> 3.10'
+  gem.add_development_dependency 'rspec-sleeping_king_studios', '~> 2.5'
+  gem.add_development_dependency 'rubocop',                     '~> 1.6'
+  gem.add_development_dependency 'rubocop-rspec',               '~> 2.1'
   gem.add_development_dependency 'simplecov',                   '~> 0.15'
 end

--- a/lib/cuprum.rb
+++ b/lib/cuprum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A lightweight, functional-lite toolkit for making business logic a first-class
 # citizen of your application.
 module Cuprum
@@ -10,6 +12,6 @@ module Cuprum
     # @return [String] The current version of the gem.
     def version
       VERSION
-    end # method version
-  end # eigenclass
-end # module
+    end
+  end
+end

--- a/lib/cuprum/built_in.rb
+++ b/lib/cuprum/built_in.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'cuprum'
 
 module Cuprum
   # Namespace for predefined command and operation classes.
   module BuiltIn; end
-end # module
+end

--- a/lib/cuprum/built_in/identity_command.rb
+++ b/lib/cuprum/built_in/identity_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in'
 require 'cuprum/command'
 
@@ -24,8 +26,8 @@ module Cuprum::BuiltIn
   class IdentityCommand < Cuprum::Command
     private
 
-    def process value = nil
+    def process(value = nil)
       value
-    end # method process
-  end # class
-end # module
+    end
+  end
+end

--- a/lib/cuprum/built_in/identity_operation.rb
+++ b/lib/cuprum/built_in/identity_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in/identity_command'
 require 'cuprum/operation'
 
@@ -23,5 +25,5 @@ module Cuprum::BuiltIn
   #   #=> ['errors.messages.unknown']
   class IdentityOperation < Cuprum::BuiltIn::IdentityCommand
     include Cuprum::Operation::Mixin
-  end # class
-end # module
+  end
+end

--- a/lib/cuprum/built_in/null_command.rb
+++ b/lib/cuprum/built_in/null_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in'
 require 'cuprum/command'
 
@@ -13,6 +15,6 @@ module Cuprum::BuiltIn
   class NullCommand < Cuprum::Command
     private
 
-    def process *_args; end
-  end # class
-end # module
+    def process(*_args); end
+  end
+end

--- a/lib/cuprum/built_in/null_operation.rb
+++ b/lib/cuprum/built_in/null_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in/null_command'
 require 'cuprum/operation'
 
@@ -12,5 +14,5 @@ module Cuprum::BuiltIn
   #   #=> true
   class NullOperation < Cuprum::BuiltIn::NullCommand
     include Cuprum::Operation::Mixin
-  end # class
-end # module
+  end
+end

--- a/lib/cuprum/command.rb
+++ b/lib/cuprum/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/currying'
 require 'cuprum/processing'
 require 'cuprum/steps'
@@ -19,14 +21,14 @@ module Cuprum
   #   class MultiplyCommand < Cuprum::Command
   #     def initialize multiplier
   #       @multiplier = multiplier
-  #     end # constructor
+  #     end
   #
   #     private
   #
   #     def process int
   #       int * @multiplier
-  #     end # method process
-  #   end # class
+  #     end
+  #   end
   #
   #   triple_command = MultiplyCommand.new(3)
   #   result         = command_command.call(5)
@@ -37,7 +39,7 @@ module Cuprum
   #   class DivideCommand < Cuprum::Command
   #     def initialize divisor
   #       @divisor = divisor
-  #     end # constructor
+  #     end
   #
   #     private
   #
@@ -47,8 +49,8 @@ module Cuprum
   #       end
   #
   #       int / @divisor
-  #     end # method process
-  #   end # class
+  #     end
+  #   end
   #
   #   halve_command = DivideCommand.new(2)
   #   result        = halve_command.call(10)
@@ -66,14 +68,14 @@ module Cuprum
   #   class AddCommand < Cuprum::Command
   #     def initialize addend
   #       @addend = addend
-  #     end # constructor
+  #     end
   #
   #     private
   #
   #     def process int
   #       int + @addend
-  #     end # method process
-  #   end # class
+  #     end
+  #   end
   #
   #   double_and_add_one = MultiplyCommand.new(2).chain(AddCommand.new(1))
   #   result             = double_and_add_one(5)
@@ -88,8 +90,8 @@ module Cuprum
   #       return int if int.even?
   #
   #       Cuprum::Errors.new(error: 'errors.messages.not_even')
-  #     end # method process
-  #   end # class
+  #     end
+  #   end
   #
   #   # The next step in a Collatz sequence is determined as follows:
   #   # - If the number is even, divide it by 2.
@@ -121,16 +123,16 @@ module Cuprum
     #   #call method will wrap the block and set the result #value to the return
     #   value of the block. This overrides the implementation in #process, if
     #   any.
-    def initialize &implementation
+    def initialize(&implementation)
       return unless implementation
 
       define_singleton_method :process, &implementation
 
       singleton_class.send(:private, :process)
-    end # method initialize
+    end
 
     def call(*args, **kwargs, &block)
       steps { super }
     end
-  end # class
-end # module
+  end
+end

--- a/lib/cuprum/command_factory.rb
+++ b/lib/cuprum/command_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum'
 
 require 'sleeping_king_studios/tools/toolbelt'
@@ -147,7 +149,7 @@ module Cuprum
       def command_class(name, **metadata, &defn)
         guard_abstract_factory!
 
-        raise ArgumentError, 'must provide a block'.freeze unless block_given?
+        raise ArgumentError, 'must provide a block' unless block_given?
 
         method_name = normalize_command_name(name)
 
@@ -227,13 +229,13 @@ module Cuprum
 
         raise NotImplementedError,
           'Cuprum::CommandFactory is an abstract class. Create a subclass to ' \
-          'define commands for a factory.'.freeze
+          'define commands for a factory.'
       end
 
       def guard_invalid_definition!(command_class)
         return if command_class.is_a?(Class) && command_class < Cuprum::Command
 
-        raise ArgumentError, 'definition must be a command class'.freeze
+        raise ArgumentError, 'definition must be a command class'
       end
 
       def normalize_command_name(command_name)
@@ -241,7 +243,7 @@ module Cuprum
       end
 
       def require_definition!
-        raise ArgumentError, 'must provide a command class or a block'.freeze
+        raise ArgumentError, 'must provide a command class or a block'
       end
 
       def tools
@@ -263,7 +265,7 @@ module Cuprum
     end
 
     # @private
-    def const_defined?(const_name, inherit = true)
+    def const_defined?(const_name, inherit = true) # rubocop:disable Style/OptionalBooleanParameter
       command?(const_name) || super
     end
 

--- a/lib/cuprum/currying/curried_command.rb
+++ b/lib/cuprum/currying/curried_command.rb
@@ -56,7 +56,9 @@ module Cuprum::Currying
     # @param arguments [Array] The arguments to pass to the curried command.
     # @param command [Cuprum::Command] The original command to curry.
     # @param keywords [Hash] The keywords to pass to the curried command.
-    def initialize(arguments: [], command:, keywords: {})
+    def initialize(command:, arguments: [], keywords: {})
+      super()
+
       @arguments = arguments
       @command   = command
       @keywords  = keywords

--- a/lib/cuprum/errors.rb
+++ b/lib/cuprum/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum'
 
 module Cuprum

--- a/lib/cuprum/operation.rb
+++ b/lib/cuprum/operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/command'
 require 'cuprum/errors/operation_not_called'
 
@@ -26,8 +28,8 @@ module Cuprum
   #       @book = operation.value
   #
   #       render :new
-  #     end # if-else
-  #   end # create
+  #     end
+  #   end
   #
   # Like a Command, an Operation can be defined directly by passing an
   # implementation block to the constructor or by creating a subclass that
@@ -41,7 +43,7 @@ module Cuprum
     # @example
     #   class CustomOperation < CustomCommand
     #     include Cuprum::Operation::Mixin
-    #   end # class
+    #   end
     module Mixin
       # @return [Cuprum::Result] The result from the most recent call of the
       #   operation.
@@ -62,32 +64,32 @@ module Cuprum
       #     implementation.
       #
       # @see Cuprum::Command#call
-      def call *args, **kwargs, &block
+      def call(*args, **kwargs, &block)
         reset! if called? # Clear reference to most recent result.
 
         @result = super
 
         self
-      end # method call
+      end
 
       # @return [Boolean] true if the operation has been called and has a
       #   reference to the most recent result; otherwise false.
       def called?
         !result.nil?
-      end # method called?
+      end
 
       # @return [Object] the error (if any) from the most recent result, or nil
       #   if the operation has not been called.
       def error
         called? ? result.error : nil
-      end # method error
+      end
 
       # @return [Boolean] true if the most recent result had an error, or false
       #   if the most recent result had no error or if the operation has not
       #   been called.
       def failure?
         called? ? result.failure? : false
-      end # method failure?
+      end
 
       # Clears the reference to the most recent call of the operation, if any.
       # This allows the result and any referenced data to be garbage collected.
@@ -99,7 +101,7 @@ module Cuprum
       # an error.
       def reset!
         @result = nil
-      end # method reset
+      end
 
       # @return [Symbol, nil] the status of the most recent result, or nil if
       #   the operation has not been called.
@@ -112,7 +114,7 @@ module Cuprum
       #   been called.
       def success?
         called? ? result.success? : false
-      end # method success?
+      end
 
       # Returns the most result if the operation was previously called.
       # Otherwise, returns a failing result.
@@ -130,8 +132,8 @@ module Cuprum
       #   operation has not been called.
       def value
         called? ? result.value : nil
-      end # method value
-    end # module
+      end
+    end
     include Mixin
 
     # @!method call
@@ -160,5 +162,5 @@ module Cuprum
 
     # @!method value
     #   (see Cuprum::Operation::Mixin#value)
-  end # class
-end # module
+  end
+end

--- a/lib/cuprum/result.rb
+++ b/lib/cuprum/result.rb
@@ -28,8 +28,6 @@ module Cuprum
     # @return [Symbol] the status of the result, either :success or :failure.
     attr_reader :status
 
-    # rubocop:disable Metrics/CyclomaticComplexity
-
     # Compares the other object to the result.
     #
     # @param other [#value, #success?] An object responding to, at minimum,
@@ -45,7 +43,6 @@ module Cuprum
 
       true
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     # @return [Boolean] true if the result status is :failure, otherwise false.
     def failure?

--- a/lib/cuprum/rspec/be_a_result_matcher.rb
+++ b/lib/cuprum/rspec/be_a_result_matcher.rb
@@ -46,9 +46,9 @@ module Cuprum::RSpec
       message = "expected #{actual.inspect} to #{description}"
 
       if !actual_is_result?
-        message + ', but the object is not a result'
+        "#{message}, but the object is not a result"
       elsif actual_is_uncalled_operation?
-        message + ', but the object is an uncalled operation'
+        "#{message}, but the object is an uncalled operation"
       elsif !properties_match?
         message + properties_failure_message
       else
@@ -182,7 +182,6 @@ module Cuprum::RSpec
       ' positives, since any other result will match.'
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/AbcSize
     def properties_description
       msg = ''
@@ -200,7 +199,6 @@ module Cuprum::RSpec
 
       msg + " and status: #{expected_status.inspect}"
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/AbcSize
 
     def properties_failure_message

--- a/lib/cuprum/steps.rb
+++ b/lib/cuprum/steps.rb
@@ -264,8 +264,10 @@ module Cuprum
     #   result.class    #=> Cuprum::Result
     #   result.success? #=> false
     #   result.error    #=> 'second step'
-    def steps
-      result = catch(:cuprum_failed_step) { yield }
+    def steps(&block)
+      raise ArgumentError, 'no block given' unless block_given?
+
+      result = catch(:cuprum_failed_step) { block.call }
 
       return result if result.respond_to?(:to_cuprum_result)
 

--- a/lib/cuprum/utils.rb
+++ b/lib/cuprum/utils.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'cuprum'
 
 module Cuprum
   # Namespace for utility modules.
   module Utils; end
-end # module
+end

--- a/lib/cuprum/version.rb
+++ b/lib/cuprum/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cuprum
   # @api private
   #
@@ -34,11 +36,11 @@ module Cuprum
         str << ".#{build}" if build
 
         str
-      end # class method to_version
+      end
 
       private
 
-      def value_of constant
+      def value_of(constant)
         return nil unless const_defined?(constant)
 
         value = const_get(constant)
@@ -46,9 +48,9 @@ module Cuprum
         return nil if value.respond_to?(:empty?) && value.empty?
 
         value
-      end # method value_of
-    end # eigenclass
-  end # module
+      end
+    end
+  end
 
   VERSION = Version.to_gem_version
-end # module
+end

--- a/spec/cuprum/built_in/identity_command_spec.rb
+++ b/spec/cuprum/built_in/identity_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in/identity_command'
 
 require 'support/examples/processing_examples'
@@ -5,53 +7,53 @@ require 'support/examples/processing_examples'
 RSpec.describe Cuprum::BuiltIn::IdentityCommand do
   include Spec::Examples::ProcessingExamples
 
-  subject(:instance) { described_class.new }
+  subject(:command) { described_class.new }
 
   include_examples 'should implement the Processing interface'
 
   describe '#call' do
-    it { expect(instance).to respond_to(:call).with(0..1).arguments }
+    it { expect(command).to respond_to(:call).with(0..1).arguments }
 
     describe 'with nil' do
       it 'should return a result', :aggregate_failures do
-        result = instance.call
+        result = command.call
 
         expect(result).to be_a Cuprum::Result
         expect(result.value).to be nil
         expect(result.error).to be nil
         expect(result.success?).to be true
         expect(result.failure?).to be false
-      end # it
-    end # describe
+      end
+    end
 
     describe 'with a value' do
-      let(:value) { 'expected value'.freeze }
+      let(:value) { 'expected value' }
 
       it 'should return a result', :aggregate_failures do
-        result = instance.call(value)
+        result = command.call(value)
 
         expect(result).to be_a Cuprum::Result
         expect(result.value).to be value
         expect(result.error).to be nil
         expect(result.success?).to be true
         expect(result.failure?).to be false
-      end # it
-    end # describe
+      end
+    end
 
     describe 'with a result' do
-      let(:value)    { 'expected value'.freeze }
+      let(:value)    { 'expected value' }
       let(:error)    { Cuprum::Error.new(message: 'Something went wrong.') }
       let(:expected) { Cuprum::Result.new(value: value, error: error) }
 
       it 'should return the result', :aggregate_failures do
-        result = instance.call(expected)
+        result = command.call(expected)
 
         expect(result).to be_a Cuprum::Result
         expect(result.value).to be value
         expect(result.error).to be == error
         expect(result.success?).to be false
         expect(result.failure?).to be true
-      end # it
-    end # describe
-  end # describe
-end # describe
+      end
+    end
+  end
+end

--- a/spec/cuprum/built_in/identity_operation_spec.rb
+++ b/spec/cuprum/built_in/identity_operation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in/identity_operation'
 
 require 'support/examples/operation_examples'
@@ -7,59 +9,60 @@ RSpec.describe Cuprum::BuiltIn::IdentityOperation do
   include Spec::Examples::OperationExamples
   include Spec::Examples::ProcessingExamples
 
-  subject(:instance) { described_class.new }
+  subject(:operation) { described_class.new }
 
-  let(:value)  { 'returned value'.freeze }
-  let(:error)  { Cuprum::Error.new(message: 'Something went wrong.') }
-  let(:result) { Cuprum::Result.new(value: value, error: error) }
+  let(:command) { operation }
+  let(:value)   { 'returned value' }
+  let(:error)   { Cuprum::Error.new(message: 'Something went wrong.') }
+  let(:result)  { Cuprum::Result.new(value: value, error: error) }
 
   include_examples 'should implement the Operation methods'
 
   include_examples 'should implement the Processing interface'
 
   describe '#call' do
-    it { expect(instance).to respond_to(:call).with(0..1).arguments }
+    it { expect(operation).to respond_to(:call).with(0..1).arguments }
 
-    it { expect(instance.call).to be instance }
-  end # describe
+    it { expect(operation.call).to be operation }
+  end
 
   describe '#error' do
-    it { expect(instance.error).to be nil }
+    it { expect(operation.error).to be nil }
 
-    it { expect(instance.call.error).to be nil }
+    it { expect(operation.call.error).to be nil }
 
-    it { expect(instance.call(value).error).to be nil }
+    it { expect(operation.call(value).error).to be nil }
 
-    it { expect(instance.call(result).error).to be == error }
-  end # describe
+    it { expect(operation.call(result).error).to be == error }
+  end
 
   describe '#failure?' do
-    it { expect(instance.failure?).to be false }
+    it { expect(operation.failure?).to be false }
 
-    it { expect(instance.call.failure?).to be false }
+    it { expect(operation.call.failure?).to be false }
 
-    it { expect(instance.call(value).failure?).to be false }
+    it { expect(operation.call(value).failure?).to be false }
 
-    it { expect(instance.call(result).failure?).to be true }
-  end # describe
+    it { expect(operation.call(result).failure?).to be true }
+  end
 
   describe '#success?' do
-    it { expect(instance.success?).to be false }
+    it { expect(operation.success?).to be false }
 
-    it { expect(instance.call.success?).to be true }
+    it { expect(operation.call.success?).to be true }
 
-    it { expect(instance.call(value).success?).to be true }
+    it { expect(operation.call(value).success?).to be true }
 
-    it { expect(instance.call(result).success?).to be false }
-  end # describe
+    it { expect(operation.call(result).success?).to be false }
+  end
 
   describe '#value' do
-    it { expect(instance.value).to be nil }
+    it { expect(operation.value).to be nil }
 
-    it { expect(instance.call.value).to be nil }
+    it { expect(operation.call.value).to be nil }
 
-    it { expect(instance.call(value).value).to be == value }
+    it { expect(operation.call(value).value).to be == value }
 
-    it { expect(instance.call(result).value).to be == value }
-  end # describe
-end # describe
+    it { expect(operation.call(result).value).to be == value }
+  end
+end

--- a/spec/cuprum/built_in/null_command_spec.rb
+++ b/spec/cuprum/built_in/null_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in/null_command'
 
 require 'support/examples/processing_examples'
@@ -5,33 +7,33 @@ require 'support/examples/processing_examples'
 RSpec.describe Cuprum::BuiltIn::NullCommand do
   include Spec::Examples::ProcessingExamples
 
-  subject(:instance) { described_class.new }
+  subject(:command) { described_class.new }
 
   include_examples 'should implement the Processing interface'
 
   describe '#call' do
-    it { expect(instance).to respond_to(:call).with(0).arguments }
+    it { expect(command).to respond_to(:call).with(0).arguments }
 
     it 'should return a result', :aggregate_failures do
-      result = instance.call
+      result = command.call
 
       expect(result).to be_a Cuprum::Result
       expect(result.value).to be nil
       expect(result.error).to be nil
       expect(result.success?).to be true
       expect(result.failure?).to be false
-    end # it
+    end
 
     describe 'with arbitrary arguments' do
       it 'should return a result', :aggregate_failures do
-        result = instance.call(1, 2, :san => 'san') { :yon }
+        result = command.call(1, 2, san: 'san') { :yon }
 
         expect(result).to be_a Cuprum::Result
         expect(result.value).to be nil
         expect(result.error).to be nil
         expect(result.success?).to be true
         expect(result.failure?).to be false
-      end # it
-    end # describe
-  end # describe
-end # describe
+      end
+    end
+  end
+end

--- a/spec/cuprum/built_in/null_operation_spec.rb
+++ b/spec/cuprum/built_in/null_operation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/built_in/null_operation'
 
 require 'support/examples/operation_examples'
@@ -7,67 +9,69 @@ RSpec.describe Cuprum::BuiltIn::NullOperation do
   include Spec::Examples::OperationExamples
   include Spec::Examples::ProcessingExamples
 
-  subject(:instance) { described_class.new }
+  subject(:operation) { described_class.new }
+
+  let(:command) { operation }
 
   include_examples 'should implement the Operation methods'
 
   include_examples 'should implement the Processing interface'
 
   describe '#call' do
-    it { expect(instance).to respond_to(:call).with(0).arguments }
+    it { expect(operation).to respond_to(:call).with(0).arguments }
 
-    it { expect(instance.call).to be instance }
+    it { expect(operation.call).to be operation }
 
     describe 'with arbitrary arguments' do
-      it { expect(instance.call(1, 2, :san => 'san') { :yon }).to be instance }
-    end # describe
-  end # describe
+      it { expect(operation.call(1, 2, san: 'san') { :yon }).to be operation }
+    end
+  end
 
   describe '#error' do
-    it { expect(instance.error).to be nil }
+    it { expect(operation.error).to be nil }
 
-    it { expect(instance.call.error).to be nil }
+    it { expect(operation.call.error).to be nil }
 
     describe 'with arbitrary arguments' do
       it 'should not set any errors' do
-        expect(instance.call(1, 2, :san => 'san') { :yon }.error).to be nil
-      end # it
-    end # describe
-  end # describe
+        expect(operation.call(1, 2, san: 'san') { :yon }.error).to be nil
+      end
+    end
+  end
 
   describe '#failure?' do
-    it { expect(instance.failure?).to be false }
+    it { expect(operation.failure?).to be false }
 
-    it { expect(instance.call.failure?).to be false }
+    it { expect(operation.call.failure?).to be false }
 
     describe 'with arbitrary arguments' do
       it 'should not set the status to failure' do
-        expect(instance.call(1, 2, :san => 'san') { :yon }.failure?).to be false
-      end # it
-    end # describe
-  end # describe
+        expect(operation.call(1, 2, san: 'san') { :yon }.failure?).to be false
+      end
+    end
+  end
 
   describe '#success?' do
-    it { expect(instance.success?).to be false }
+    it { expect(operation.success?).to be false }
 
-    it { expect(instance.call.success?).to be true }
+    it { expect(operation.call.success?).to be true }
 
     describe 'with arbitrary arguments' do
       it 'should set the status to success' do
-        expect(instance.call(1, 2, :san => 'san') { :yon }.success?).to be true
-      end # it
-    end # describe
-  end # describe
+        expect(operation.call(1, 2, san: 'san') { :yon }.success?).to be true
+      end
+    end
+  end
 
   describe '#value' do
-    it { expect(instance.value).to be nil }
+    it { expect(operation.value).to be nil }
 
-    it { expect(instance.call.value).to be nil }
+    it { expect(operation.call.value).to be nil }
 
     describe 'with arbitrary arguments' do
       it 'should set the value to nil' do
-        expect(instance.call(1, 2, :san => 'san') { :yon }.value).to be nil
-      end # it
-    end # describe
-  end # describe
-end # describe
+        expect(operation.call(1, 2, san: 'san') { :yon }.value).to be nil
+      end
+    end
+  end
+end

--- a/spec/cuprum/command_factory_spec.rb
+++ b/spec/cuprum/command_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/command'
 require 'cuprum/command_factory'
 
@@ -58,7 +60,7 @@ RSpec.describe Cuprum::CommandFactory do
   end
 
   shared_context 'when the factory defines a custom #build_command method' do
-    let(:default_options) { { state: { value: 'a value'.freeze } } }
+    let(:default_options) { { state: { value: 'a value' } } }
 
     before(:example) do
       opts = default_options
@@ -120,8 +122,8 @@ RSpec.describe Cuprum::CommandFactory do
         end
 
         describe 'with arguments' do
-          let(:value)     { 'value'.freeze }
-          let(:options)   { { key: 'option'.freeze } }
+          let(:value)     { 'value' }
+          let(:options)   { { key: 'option' } }
           let(:arguments) { [value] }
 
           it { expect(build_command).to be_a command_class }
@@ -159,8 +161,8 @@ RSpec.describe Cuprum::CommandFactory do
     end
 
     describe 'with arguments' do
-      let(:value)     { 'value'.freeze }
-      let(:options)   { { key: 'option'.freeze } }
+      let(:value)     { 'value' }
+      let(:options)   { { key: 'option' } }
       let(:arguments) { [value] }
 
       it { expect(command).to be_a command_class }

--- a/spec/cuprum/command_spec.rb
+++ b/spec/cuprum/command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/command'
 
 require 'support/examples/currying_examples'
@@ -11,14 +13,14 @@ RSpec.describe Cuprum::Command do
   include Spec::Examples::ResultHelpersExamples
   include Spec::Examples::StepsExamples
 
-  subject(:instance) { described_class.new }
+  subject(:command) { described_class.new }
 
-  let(:implementation) { ->() {} }
+  let(:implementation) { -> {} }
   let(:result_class)   { Cuprum::Result }
 
   describe '::new' do
     it { expect(described_class).to be_constructible.with(0).arguments }
-  end # describe
+  end
 
   include_examples 'should implement the Currying interface'
 
@@ -37,12 +39,12 @@ RSpec.describe Cuprum::Command do
   include_examples 'should implement the Steps methods'
 
   describe '#call' do
-    let(:implementation) { ->() {} }
+    let(:implementation) { -> {} }
 
     context 'when the command is initialized with a block' do
       shared_context 'when the implementation is defined' do
-        subject(:instance) { described_class.new(&implementation) }
-      end # shared_context
+        subject(:command) { described_class.new(&implementation) }
+      end
 
       include_examples 'should execute the command implementation'
 
@@ -53,14 +55,14 @@ RSpec.describe Cuprum::Command do
         let(:implementation) do
           thrown = result
 
-          ->() { throw :cuprum_failed_step, thrown }
+          -> { throw :cuprum_failed_step, thrown }
         end
 
         it 'should return the thrown result' do
-          expect(instance.call).to be result
+          expect(command.call).to be result
         end
       end
-    end # context
+    end
 
     context 'when the #process method is defined' do
       shared_context 'when the implementation is defined' do
@@ -69,9 +71,9 @@ RSpec.describe Cuprum::Command do
 
           Class.new(super()) do |klass|
             klass.send(:define_method, :process, &process)
-          end # class
-        end # let
-      end # shared_context
+          end
+        end
+      end
 
       include_examples 'should execute the command implementation'
 
@@ -82,13 +84,13 @@ RSpec.describe Cuprum::Command do
         let(:implementation) do
           thrown = result
 
-          ->() { throw :cuprum_failed_step, thrown }
+          -> { throw :cuprum_failed_step, thrown }
         end
 
         it 'should return the thrown result' do
-          expect(instance.call).to be result
+          expect(command.call).to be result
         end
       end
-    end # context
-  end # describe
-end # describe
+    end
+  end
+end

--- a/spec/cuprum/currying/curried_command_spec.rb
+++ b/spec/cuprum/currying/curried_command_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Cuprum::Currying::CurriedCommand do
       end
 
       it 'should yield the block to the command' do
-        allow(command).to receive(:call) { |&block| block.call }
+        allow(command).to receive(:call).and_yield
 
         expect { |block| call_curried_command(&block) }.to yield_control
       end

--- a/spec/cuprum/currying_spec.rb
+++ b/spec/cuprum/currying_spec.rb
@@ -7,7 +7,7 @@ require 'support/examples/currying_examples'
 RSpec.describe Cuprum::Currying do
   include Spec::Examples::CurryingExamples
 
-  subject(:instance) { described_class.new }
+  subject { described_class.new }
 
   let(:described_class) { Class.new { include Cuprum::Currying } }
 

--- a/spec/cuprum/errors/command_not_implemented_spec.rb
+++ b/spec/cuprum/errors/command_not_implemented_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Cuprum::Errors::CommandNotImplemented do
     end
 
     describe 'with a non-matching Error with no message' do
-      let(:other) { Cuprum::Error.new(message: 'An error occurred.') }
+      let(:other) { Cuprum::Error.new }
 
       it { expect(error == other).to be false }
     end

--- a/spec/cuprum/errors/operation_not_called_spec.rb
+++ b/spec/cuprum/errors/operation_not_called_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Cuprum::Errors::OperationNotCalled do
     end
 
     describe 'with a non-matching Error with no message' do
-      let(:other) { Cuprum::Error.new(message: 'An error occurred.') }
+      let(:other) { Cuprum::Error.new }
 
       it { expect(error == other).to be false }
     end

--- a/spec/cuprum/integration/command_factory_spec.rb
+++ b/spec/cuprum/integration/command_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/command'
 require 'cuprum/command_factory'
 
@@ -31,6 +33,8 @@ module Spec
 
   class PublishBookCommand < Cuprum::Command
     def initialize(publisher:)
+      super()
+
       @publisher = publisher
     end
 
@@ -90,6 +94,8 @@ module Spec
     end
 
     def initialize(books:)
+      super()
+
       @books_collection = books
     end
 
@@ -121,7 +127,7 @@ RSpec.describe Spec::BookFactory do # rubocop:disable RSpec/FilePath
 
     it { expect(instance.build).to be_a Spec::BuildBookCommand }
 
-    it 'should build a book' do
+    it 'should build a book', :aggregate_failures do
       command = instance.build
       result  = command.call(attributes, **{})
       book    = result.value
@@ -189,7 +195,7 @@ RSpec.describe Spec::BookFactory do # rubocop:disable RSpec/FilePath
 
     it { expect(instance.save).to be_a instance::Save }
 
-    it 'should save the book' do
+    it 'should save the book', :aggregate_failures do
       command = instance.save
 
       expect { command.call(book) }.to change(books_collection, :count).by(1)
@@ -206,7 +212,7 @@ RSpec.describe Spec::BookFactory do # rubocop:disable RSpec/FilePath
     describe 'with an invalid book' do
       let(:book) { Spec::Book.new title: 'The Tombs of Atuan' }
 
-      it 'should validate the book' do
+      it 'should validate the book', :aggregate_failures do
         command = instance.validate
         result  = command.call(book)
         error   = result.error
@@ -223,7 +229,7 @@ RSpec.describe Spec::BookFactory do # rubocop:disable RSpec/FilePath
         Spec::Book.new title: 'The Farthest Shore', author: 'Ursula K. Le Guin'
       end
 
-      it 'should validate the book' do
+      it 'should validate the book', :aggregate_failures do
         command = instance.validate
         result  = command.call(book)
 

--- a/spec/cuprum/operation_spec.rb
+++ b/spec/cuprum/operation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/operation'
 
 require 'support/examples/currying_examples'
@@ -13,14 +15,15 @@ RSpec.describe Cuprum::Operation do
   include Spec::Examples::ResultHelpersExamples
   include Spec::Examples::StepsExamples
 
-  subject(:instance) { described_class.new }
+  subject(:operation) { described_class.new }
 
-  let(:implementation) { ->() {} }
+  let(:command)        { operation }
+  let(:implementation) { -> {} }
   let(:expected_class) { described_class }
 
   describe '::new' do
     it { expect(described_class).to be_constructible.with(0).arguments }
-  end # describe
+  end
 
   include_examples 'should implement the Currying interface'
 
@@ -41,12 +44,12 @@ RSpec.describe Cuprum::Operation do
   include_examples 'should implement the Steps methods'
 
   describe '#call' do
-    let(:implementation) { ->() {} }
+    let(:implementation) { -> {} }
 
     context 'when the operation is initialized with a block' do
       shared_context 'when the implementation is defined' do
-        subject(:instance) { described_class.new(&implementation) }
-      end # shared_context
+        subject(:command) { described_class.new(&implementation) }
+      end
 
       include_examples 'should execute the command implementation'
 
@@ -57,18 +60,18 @@ RSpec.describe Cuprum::Operation do
         let(:implementation) do
           thrown = result
 
-          ->() { throw :cuprum_failed_step, thrown }
+          -> { throw :cuprum_failed_step, thrown }
         end
 
         it 'should return the operation' do
-          expect(instance.call).to be instance
+          expect(command.call).to be command
         end
 
         it 'should set the operation result to the thrown result' do
-          expect(instance.call.result).to be result
+          expect(command.call.result).to be result
         end
       end
-    end # context
+    end
 
     context 'when the #process method is defined' do
       shared_context 'when the implementation is defined' do
@@ -77,9 +80,9 @@ RSpec.describe Cuprum::Operation do
 
           Class.new(super()) do |klass|
             klass.send(:define_method, :process, &process)
-          end # class
-        end # let
-      end # shared_context
+          end
+        end
+      end
 
       include_examples 'should execute the command implementation'
 
@@ -90,17 +93,17 @@ RSpec.describe Cuprum::Operation do
         let(:implementation) do
           thrown = result
 
-          ->() { throw :cuprum_failed_step, thrown }
+          -> { throw :cuprum_failed_step, thrown }
         end
 
         it 'should return the operation' do
-          expect(instance.call).to be instance
+          expect(command.call).to be command
         end
 
         it 'should set the operation result to the thrown result' do
-          expect(instance.call.result).to be result
+          expect(command.call.result).to be result
         end
       end
-    end # context
-  end # describe
-end # describe
+    end
+  end
+end

--- a/spec/cuprum/processing_spec.rb
+++ b/spec/cuprum/processing_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Cuprum::Processing do
   include Spec::Examples::ProcessingExamples
   include Spec::Examples::ResultHelpersExamples
 
-  subject(:instance) { described_class.new }
+  subject(:command) { described_class.new }
 
   let(:described_class) { Class.new { include Cuprum::Processing } }
 

--- a/spec/cuprum/result/with_custom_status_spec.rb
+++ b/spec/cuprum/result/with_custom_status_spec.rb
@@ -8,7 +8,7 @@ require 'cuprum/result'
 require 'support/examples/result_examples'
 require 'support/halting_result'
 
-RSpec.describe Cuprum::Result do
+RSpec.describe Cuprum::Result do # rubocop:disable RSpec/FilePath
   include Spec::Examples::ResultExamples
 
   context 'with a subclass with custom statuses' do
@@ -16,7 +16,7 @@ RSpec.describe Cuprum::Result do
       before(:example) { params[:status] = :halted }
     end
 
-    subject(:instance) { described_class.new(**params) }
+    subject(:result) { described_class.new(**params) }
 
     let(:described_class) { Spec::HaltingResult }
     let(:params) { {} }
@@ -97,8 +97,9 @@ RSpec.describe Cuprum::Result do
       }
       error_scenarios = {
         'a nil error'          => nil,
-        'a non-matching error' =>
-          Cuprum::Error.new(message: 'Other error message.')
+        'a non-matching error' => Cuprum::Error.new(
+          message: 'Other error message.'
+        )
       }
       status_scenarios = {
         ''                 => nil,
@@ -115,7 +116,7 @@ RSpec.describe Cuprum::Result do
       # rubocop:disable RSpec/NestedGroups
       describe 'with nil' do
         # rubocop:disable Style/NilComparison
-        it { expect(instance == nil).to be false }
+        it { expect(result == nil).to be false }
         # rubocop:enable Style/NilComparison
       end
 
@@ -124,8 +125,7 @@ RSpec.describe Cuprum::Result do
 
       wrap_context 'when the result has a value' do
         all_scenarios = {
-          value:
-            value_scenarios.merge('a matching value' => 'returned value'),
+          value:  value_scenarios.merge('a matching value' => 'returned value'),
           error:  error_scenarios,
           status: status_scenarios.merge('status: :halted' => :halted)
         }
@@ -184,8 +184,7 @@ RSpec.describe Cuprum::Result do
         include_context 'when the result has an error'
 
         all_scenarios = {
-          value:
-            value_scenarios.merge('a matching value' => 'returned value'),
+          value:  value_scenarios.merge('a matching value' => 'returned value'),
           error:  error_scenarios.merge(
             'a matching error' => Cuprum::Error.new(
               message: 'Something went wrong.'
@@ -234,31 +233,31 @@ RSpec.describe Cuprum::Result do
       include_examples 'should have predicate', :failure?, false
 
       wrap_context 'when the result has an error' do
-        it { expect(instance.failure?).to be true }
+        it { expect(result.failure?).to be true }
 
         wrap_context 'when the result has status: :failure' do
-          it { expect(instance.failure?).to be true }
+          it { expect(result.failure?).to be true }
         end
 
         wrap_context 'when the result has status: :halted' do
-          it { expect(instance.failure?).to be false }
+          it { expect(result.failure?).to be false }
         end
 
         wrap_context 'when the result has status: :success' do
-          it { expect(instance.failure?).to be false }
+          it { expect(result.failure?).to be false }
         end
       end
 
       wrap_context 'when the result has status: :failure' do
-        it { expect(instance.failure?).to be true }
+        it { expect(result.failure?).to be true }
       end
 
       wrap_context 'when the result has status: :halted' do
-        it { expect(instance.failure?).to be false }
+        it { expect(result.failure?).to be false }
       end
 
       wrap_context 'when the result has status: :success' do
-        it { expect(instance.failure?).to be false }
+        it { expect(result.failure?).to be false }
       end
     end
 
@@ -266,31 +265,31 @@ RSpec.describe Cuprum::Result do
       include_examples 'should have predicate', :halted?, false
 
       wrap_context 'when the result has an error' do
-        it { expect(instance.halted?).to be false }
+        it { expect(result.halted?).to be false }
 
         wrap_context 'when the result has status: :failure' do
-          it { expect(instance.halted?).to be false }
+          it { expect(result.halted?).to be false }
         end
 
         wrap_context 'when the result has status: :halted' do
-          it { expect(instance.halted?).to be true }
+          it { expect(result.halted?).to be true }
         end
 
         wrap_context 'when the result has status: :success' do
-          it { expect(instance.halted?).to be false }
+          it { expect(result.halted?).to be false }
         end
       end
 
       wrap_context 'when the result has status: :failure' do
-        it { expect(instance.halted?).to be false }
+        it { expect(result.halted?).to be false }
       end
 
       wrap_context 'when the result has status: :halted' do
-        it { expect(instance.halted?).to be true }
+        it { expect(result.halted?).to be true }
       end
 
       wrap_context 'when the result has status: :success' do
-        it { expect(instance.halted?).to be false }
+        it { expect(result.halted?).to be false }
       end
     end
 
@@ -298,31 +297,31 @@ RSpec.describe Cuprum::Result do
       include_examples 'should have predicate', :success?, true
 
       wrap_context 'when the result has an error' do
-        it { expect(instance.success?).to be false }
+        it { expect(result.success?).to be false }
 
         wrap_context 'when the result has status: :failure' do
-          it { expect(instance.success?).to be false }
+          it { expect(result.success?).to be false }
         end
 
         wrap_context 'when the result has status: :halted' do
-          it { expect(instance.success?).to be false }
+          it { expect(result.success?).to be false }
         end
 
         wrap_context 'when the result has status: :success' do
-          it { expect(instance.success?).to be true }
+          it { expect(result.success?).to be true }
         end
       end
 
       wrap_context 'when the result has status: :failure' do
-        it { expect(instance.success?).to be false }
+        it { expect(result.success?).to be false }
       end
 
       wrap_context 'when the result has status: :halted' do
-        it { expect(instance.success?).to be false }
+        it { expect(result.success?).to be false }
       end
 
       wrap_context 'when the result has status: :success' do
-        it { expect(instance.success?).to be true }
+        it { expect(result.success?).to be true }
       end
     end
   end

--- a/spec/cuprum/result_helpers_spec.rb
+++ b/spec/cuprum/result_helpers_spec.rb
@@ -7,7 +7,7 @@ require 'support/examples/result_helpers_examples'
 RSpec.describe Cuprum::ResultHelpers do
   include Spec::Examples::ResultHelpersExamples
 
-  subject(:instance) { described_class.new }
+  subject { described_class.new }
 
   let(:described_class) { Class.new { include Cuprum::ResultHelpers } }
 

--- a/spec/cuprum/result_spec.rb
+++ b/spec/cuprum/result_spec.rb
@@ -8,7 +8,7 @@ require 'support/examples/result_examples'
 RSpec.describe Cuprum::Result do
   include Spec::Examples::ResultExamples
 
-  subject(:instance) { described_class.new(**params) }
+  subject(:result) { described_class.new(**params) }
 
   let(:params) { {} }
 
@@ -74,8 +74,9 @@ RSpec.describe Cuprum::Result do
     }
     error_scenarios = {
       'a nil error'          => nil,
-      'a non-matching error' =>
-        Cuprum::Error.new(message: 'Other error message.')
+      'a non-matching error' => Cuprum::Error.new(
+        message: 'Other error message.'
+      )
     }
     status_scenarios = {
       ''                 => nil,
@@ -90,7 +91,7 @@ RSpec.describe Cuprum::Result do
 
     describe 'with nil' do
       # rubocop:disable Style/NilComparison
-      it { expect(instance == nil).to be false }
+      it { expect(result == nil).to be false }
       # rubocop:enable Style/NilComparison
     end
 
@@ -99,8 +100,7 @@ RSpec.describe Cuprum::Result do
 
     wrap_context 'when the result has a value' do
       all_scenarios = {
-        value:
-          value_scenarios.merge('a matching value' => 'returned value'),
+        value:  value_scenarios.merge('a matching value' => 'returned value'),
         error:  error_scenarios,
         status: status_scenarios
       }
@@ -149,8 +149,7 @@ RSpec.describe Cuprum::Result do
       include_context 'when the result has an error'
 
       all_scenarios = {
-        value:
-          value_scenarios.merge('a matching value' => 'returned value'),
+        value:  value_scenarios.merge('a matching value' => 'returned value'),
         error:  error_scenarios.merge(
           'a matching error' => Cuprum::Error.new(
             message: 'Something went wrong.'
@@ -190,7 +189,7 @@ RSpec.describe Cuprum::Result do
     include_examples 'should not have writer', :error
 
     wrap_context 'when the result has an error' do
-      it { expect(instance.error).to be error }
+      it { expect(result.error).to be error }
     end
   end
 
@@ -198,23 +197,23 @@ RSpec.describe Cuprum::Result do
     include_examples 'should have predicate', :failure?, false
 
     wrap_context 'when the result has an error' do
-      it { expect(instance.failure?).to be true }
+      it { expect(result.failure?).to be true }
 
       wrap_context 'when the result has status: :failure' do
-        it { expect(instance.failure?).to be true }
+        it { expect(result.failure?).to be true }
       end
 
       wrap_context 'when the result has status: :success' do
-        it { expect(instance.failure?).to be false }
+        it { expect(result.failure?).to be false }
       end
     end
 
     wrap_context 'when the result has status: :failure' do
-      it { expect(instance.failure?).to be true }
+      it { expect(result.failure?).to be true }
     end
 
     wrap_context 'when the result has status: :success' do
-      it { expect(instance.failure?).to be false }
+      it { expect(result.failure?).to be false }
     end
   end
 
@@ -222,23 +221,23 @@ RSpec.describe Cuprum::Result do
     include_examples 'should have reader', :status, :success
 
     wrap_context 'when the result has an error' do
-      it { expect(instance.status).to be :failure }
+      it { expect(result.status).to be :failure }
 
       wrap_context 'when the result has status: :failure' do
-        it { expect(instance.status).to be :failure }
+        it { expect(result.status).to be :failure }
       end
 
       wrap_context 'when the result has status: :success' do
-        it { expect(instance.status).to be :success }
+        it { expect(result.status).to be :success }
       end
     end
 
     wrap_context 'when the result has status: :failure' do
-      it { expect(instance.status).to be :failure }
+      it { expect(result.status).to be :failure }
     end
 
     wrap_context 'when the result has status: :success' do
-      it { expect(instance.status).to be :success }
+      it { expect(result.status).to be :success }
     end
   end
 
@@ -246,28 +245,28 @@ RSpec.describe Cuprum::Result do
     include_examples 'should have predicate', :success?, true
 
     wrap_context 'when the result has an error' do
-      it { expect(instance.success?).to be false }
+      it { expect(result.success?).to be false }
 
       wrap_context 'when the result has status: :failure' do
-        it { expect(instance.success?).to be false }
+        it { expect(result.success?).to be false }
       end
 
       wrap_context 'when the result has status: :success' do
-        it { expect(instance.success?).to be true }
+        it { expect(result.success?).to be true }
       end
     end
 
     wrap_context 'when the result has status: :failure' do
-      it { expect(instance.success?).to be false }
+      it { expect(result.success?).to be false }
     end
 
     wrap_context 'when the result has status: :success' do
-      it { expect(instance.success?).to be true }
+      it { expect(result.success?).to be true }
     end
   end
 
   describe '#to_cuprum_result' do
-    include_examples 'should have reader', :to_cuprum_result, ->() { instance }
+    include_examples 'should have reader', :to_cuprum_result, -> { result }
   end
 
   describe '#value' do
@@ -279,14 +278,14 @@ RSpec.describe Cuprum::Result do
       let(:value)  { 'result value' }
       let(:params) { super().merge(value: value) }
 
-      it { expect(instance.value).to be value }
+      it { expect(result.value).to be value }
     end
 
     context 'when initialized with a string value' do
       let(:value)  { { key: 'returned value' } }
       let(:params) { super().merge(value: value) }
 
-      it { expect(instance.value).to be value }
+      it { expect(result.value).to be value }
     end
   end
 end

--- a/spec/cuprum/rspec/be_a_result_matcher_spec.rb
+++ b/spec/cuprum/rspec/be_a_result_matcher_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
     it { expect(matcher.description).to be == expected }
 
     wrap_context 'with an error expectation' do
-      let(:expected) { super() + ' with the expected error' }
+      let(:expected) { "#{super()} with the expected error" }
 
       it { expect(matcher.description).to be == expected }
     end
@@ -94,7 +94,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
     end
 
     wrap_context 'with a value expectation' do
-      let(:expected) { super() + ' with the expected value' }
+      let(:expected) { "#{super()} with the expected value" }
 
       it { expect(matcher.description).to be == expected }
     end
@@ -110,7 +110,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
 
     wrap_context 'with an error and a value expectation' do
       let(:expected) do
-        super() + ' with the expected value and error'
+        "#{super()} with the expected value and error"
       end
 
       it { expect(matcher.description).to be == expected }
@@ -304,7 +304,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
     describe 'with nil' do
       let(:actual) { nil }
       let(:failure_message) do
-        super() + ', but the object is not a result'
+        "#{super()}, but the object is not a result"
       end
 
       it { expect(matcher.matches? nil).to be false }
@@ -315,7 +315,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
     describe 'with an Object' do
       let(:actual) { Object.new.freeze }
       let(:failure_message) do
-        super() + ', but the object is not a result'
+        "#{super()}, but the object is not a result"
       end
 
       it { expect(matcher.matches? actual).to be false }
@@ -332,7 +332,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
     describe 'with an uncalled Cuprum::Operation' do
       let(:actual) { Cuprum::Operation.new }
       let(:failure_message) do
-        super() + ', but the object is an uncalled operation'
+        "#{super()}, but the object is an uncalled operation"
       end
 
       it { expect(matcher.matches? actual).to be false }
@@ -387,7 +387,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -398,7 +398,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -416,7 +416,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -526,7 +526,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -537,7 +537,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -555,7 +555,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -603,13 +603,13 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       end
 
       let(:description) do
-        super() + ' with the expected error'
+        "#{super()} with the expected error"
       end
 
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -620,7 +620,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -638,7 +638,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -689,7 +689,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
 
       let(:expected_error) { an_instance_of(Spec::CustomError) }
       let(:description) do
-        super() + ' with the expected error'
+        "#{super()} with the expected error"
       end
 
       example_class 'Spec::CustomError', Cuprum::Error
@@ -697,7 +697,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -708,7 +708,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -726,7 +726,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -773,13 +773,13 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
 
       let(:expected_value) { nil }
       let(:description) do
-        super() + ' with the expected value'
+        "#{super()} with the expected value"
       end
 
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -790,7 +790,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -808,7 +808,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -854,13 +854,13 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       end
 
       let(:description) do
-        super() + ' with the expected value'
+        "#{super()} with the expected value"
       end
 
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -871,7 +871,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -889,7 +889,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -936,13 +936,13 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
 
       let(:expected_value) { an_instance_of(String) }
       let(:description) do
-        super() + ' with the expected value'
+        "#{super()} with the expected value"
       end
 
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -953,7 +953,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -971,7 +971,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1053,13 +1053,13 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       end
 
       let(:description) do
-        super() + ' with the expected error and status: :failure'
+        "#{super()} with the expected error and status: :failure"
       end
 
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -1070,7 +1070,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1088,7 +1088,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1170,13 +1170,13 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       end
 
       let(:description) do
-        super() + ' with the expected value and error'
+        "#{super()} with the expected value and error"
       end
 
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -1187,7 +1187,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1205,7 +1205,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1277,13 +1277,13 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       end
 
       let(:description) do
-        super() + ' with the expected value and status: :success'
+        "#{super()} with the expected value and status: :success"
       end
 
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -1294,7 +1294,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1312,7 +1312,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1500,7 +1500,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with nil' do
         let(:actual) { nil }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? nil).to be false }
@@ -1511,7 +1511,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an Object' do
         let(:actual) { Object.new.freeze }
         let(:failure_message) do
-          super() + ', but the object is not a result'
+          "#{super()}, but the object is not a result"
         end
 
         it { expect(matcher.matches? actual).to be false }
@@ -1529,7 +1529,7 @@ RSpec.describe Cuprum::RSpec::BeAResultMatcher do
       describe 'with an uncalled Cuprum::Operation' do
         let(:actual) { Cuprum::Operation.new }
         let(:failure_message) do
-          super() + ', but the object is an uncalled operation'
+          "#{super()}, but the object is an uncalled operation"
         end
 
         it { expect(matcher.matches? actual).to be false }

--- a/spec/cuprum/steps_spec.rb
+++ b/spec/cuprum/steps_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Cuprum::Steps do
   include Spec::Examples::ResultHelpersExamples
   include Spec::Examples::StepsExamples
 
-  subject(:instance) { described_class.new }
+  subject { described_class.new }
 
   let(:described_class) do
     Class.new do

--- a/spec/cuprum/utils/instance_spy_spec.rb
+++ b/spec/cuprum/utils/instance_spy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cuprum/command'
 require 'cuprum/operation'
 require 'cuprum/utils/instance_spy'
@@ -6,27 +8,27 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
   shared_context 'when there is an instance spy on a command class' do
     let(:command_class) do
       defined?(super()) ? super() : Spec::ExampleCommand
-    end # let
+    end
     let(:instance_spy) { described_class.spy_on(command_class) }
 
     before(:example) do
       allow(instance_spy).to receive(:call)
-    end # before example
-  end # shared_context
+    end
+  end
 
-  options = { :base_class => Cuprum::Command }
-  example_class 'Spec::ExampleCommand', options do |klass|
+  example_class 'Spec::ExampleCommand', base_class: Cuprum::Operation \
+  do |klass|
     klass.send :define_method, :process do |*_args|
-      'returned_value'.freeze
-    end # define_method
-  end # example_class
+      'returned_value'
+    end
+  end
 
-  options = { :base_class => Cuprum::Operation }
-  example_class 'Spec::ExampleOperation', options do |klass|
+  example_class 'Spec::ExampleOperation', base_class: Cuprum::Operation \
+  do |klass|
     klass.send :define_method, :process do |*_args|
-      'returned_value'.freeze
-    end # define_method
-  end # example_class
+      'returned_value'
+    end
+  end
 
   describe '::clear_spies' do
     it { expect(described_class).to respond_to(:clear_spies).with(0).arguments }
@@ -44,7 +46,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         command_instance.call
 
         expect(instance_spy).not_to have_received(:call)
-      end # it
+      end
 
       it 'should not clear instance spies in other threads' do
         Thread.new { described_class.clear_spies }.join
@@ -52,14 +54,14 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         command_instance.call
 
         expect(instance_spy).to have_received(:call)
-      end # it
-    end # context
-  end # describe
+      end
+    end
+  end
 
   describe '::spy_on' do
     let(:command_arguments) do
       ['ichi', 'ni', 'san', { 'yon' => 4, 'go' => 5 }]
-    end # let
+    end
 
     after(:example) { described_class.clear_spies }
 
@@ -68,23 +70,23 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
     describe 'with nil' do
       it 'should raise an error' do
         expect { described_class.spy_on nil }.to raise_error ArgumentError
-      end # it
-    end # describe
+      end
+    end
 
     describe 'with a class' do
       it 'should raise an error' do
         expect { described_class.spy_on Object }.to raise_error ArgumentError
-      end # it
-    end # describe
+      end
+    end
 
     describe 'with a command instance' do
       let(:command_class) { Spec::ExampleCommand.new }
 
       it 'should raise an error' do
-        expect { described_class.spy_on command_class }.
-          to raise_error ArgumentError
-      end # it
-    end # describe
+        expect { described_class.spy_on command_class }
+          .to raise_error ArgumentError
+      end
+    end
 
     describe 'with a command class' do
       let(:command_class)    { Spec::ExampleCommand }
@@ -94,7 +96,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         spy = described_class.spy_on(command_class)
 
         expect(spy).to be_a described_class::Spy
-      end # it
+      end
 
       it 'should instrument calls to #call' do
         spy = described_class.spy_on(command_class)
@@ -104,7 +106,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         command_instance.call(*command_arguments)
 
         expect(spy).to have_received(:call).with(*command_arguments)
-      end # it
+      end
 
       it 'should execute the command implementation' do
         allow(command_instance).to receive(:process)
@@ -113,35 +115,35 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
 
         command_instance.call(*command_arguments)
 
-        expect(command_instance).
-          to have_received(:process).
-          with(*command_arguments)
-      end # it
+        expect(command_instance)
+          .to have_received(:process)
+          .with(*command_arguments)
+      end
 
       wrap_context 'when there is an instance spy on a command class' do
         it 'should return the existing spy' do
           expect(described_class.spy_on(command_class)).to be instance_spy
-        end # it
-      end # wrap_context
-    end # describe
+        end
+      end
+    end
 
     describe 'with a command class and a block' do
       let(:command_class)    { Spec::ExampleCommand }
       let(:command_instance) { command_class.new }
 
-      it { expect(described_class.spy_on(command_class) {}).to be nil }
+      it { expect(described_class.spy_on(command_class) { nil }).to be nil }
 
-      it 'should yield a spy' do
+      it 'should yield a spy', :aggregate_failures do
         block_called = false
 
         described_class.spy_on(command_class) do |spy|
           block_called = true
 
           expect(spy).to be_a described_class::Spy
-        end # spy_on
+        end
 
         expect(block_called).to be true
-      end # it
+      end
 
       it 'should instrument calls to #call' do
         described_class.spy_on(command_class) do |spy|
@@ -150,37 +152,37 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
           command_instance.call(*command_arguments)
 
           expect(spy).to have_received(:call).with(*command_arguments)
-        end # spy_on
-      end # it
+        end
+      end
 
       it 'should execute the command implementation' do
         allow(command_instance).to receive(:process)
 
         described_class.spy_on(command_class) do
           command_instance.call(*command_arguments)
-        end # spy_on
+        end
 
-        expect(command_instance).
-          to have_received(:process).
-          with(*command_arguments)
-      end # it
+        expect(command_instance)
+          .to have_received(:process)
+          .with(*command_arguments)
+      end
 
       wrap_context 'when there is an instance spy on a command class' do
-        it { expect(described_class.spy_on(command_class) {}).to be nil }
+        it { expect(described_class.spy_on(command_class) { nil }).to be nil }
 
-        it 'should yield the existing spy' do
+        it 'should yield the existing spy', :aggregate_failures do
           block_called = false
 
           described_class.spy_on(command_class) do |spy|
             block_called = true
 
             expect(spy).to be instance_spy
-          end # spy_on
+          end
 
           expect(block_called).to be true
-        end # it
-      end # wrap_context
-    end # describe
+        end
+      end
+    end
 
     describe 'with Cuprum::Command' do
       let(:command_class)    { Spec::ExampleCommand }
@@ -190,7 +192,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         spy = described_class.spy_on(Cuprum::Command)
 
         expect(spy).to be_a described_class::Spy
-      end # it
+      end
 
       it 'should instrument calls to #call on a subclass' do
         spy = described_class.spy_on(Cuprum::Command)
@@ -200,8 +202,8 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         command_instance.call(*command_arguments)
 
         expect(spy).to have_received(:call).with(*command_arguments)
-      end # it
-    end # describe
+      end
+    end
 
     describe 'with an operation class' do
       let(:command_class)    { Spec::ExampleOperation }
@@ -211,7 +213,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         spy = described_class.spy_on(command_class)
 
         expect(spy).to be_a described_class::Spy
-      end # it
+      end
 
       it 'should instrument calls to #call' do
         spy = described_class.spy_on(command_class)
@@ -221,7 +223,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         command_instance.call(*command_arguments)
 
         expect(spy).to have_received(:call).with(*command_arguments)
-      end # it
+      end
 
       it 'should execute the command implementation' do
         allow(command_instance).to receive(:process)
@@ -230,35 +232,35 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
 
         command_instance.call(*command_arguments)
 
-        expect(command_instance).
-          to have_received(:process).
-          with(*command_arguments)
-      end # it
+        expect(command_instance)
+          .to have_received(:process)
+          .with(*command_arguments)
+      end
 
       wrap_context 'when there is an instance spy on a command class' do
         it 'should return the existing spy' do
           expect(described_class.spy_on(command_class)).to be instance_spy
-        end # it
-      end # wrap_context
-    end # describe
+        end
+      end
+    end
 
     describe 'with an operation class and a block' do
       let(:command_class)    { Spec::ExampleOperation }
       let(:command_instance) { command_class.new }
 
-      it { expect(described_class.spy_on(command_class) {}).to be nil }
+      it { expect(described_class.spy_on(command_class) { nil }).to be nil }
 
-      it 'should yield a spy' do
+      it 'should yield a spy', :aggregate_failures do
         block_called = false
 
         described_class.spy_on(command_class) do |spy|
           block_called = true
 
           expect(spy).to be_a described_class::Spy
-        end # spy_on
+        end
 
         expect(block_called).to be true
-      end # it
+      end
 
       it 'should instrument calls to #call' do
         described_class.spy_on(command_class) do |spy|
@@ -267,37 +269,37 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
           command_instance.call(*command_arguments)
 
           expect(spy).to have_received(:call).with(*command_arguments)
-        end # spy_on
-      end # it
+        end
+      end
 
       it 'should execute the command implementation' do
         allow(command_instance).to receive(:process)
 
         described_class.spy_on(command_class) do
           command_instance.call(*command_arguments)
-        end # spy_on
+        end
 
-        expect(command_instance).
-          to have_received(:process).
-          with(*command_arguments)
-      end # it
+        expect(command_instance)
+          .to have_received(:process)
+          .with(*command_arguments)
+      end
 
       wrap_context 'when there is an instance spy on a command class' do
-        it { expect(described_class.spy_on(command_class) {}).to be nil }
+        it { expect(described_class.spy_on(command_class) { nil }).to be nil }
 
-        it 'should yield the existing spy' do
+        it 'should yield the existing spy', :aggregate_failures do
           block_called = false
 
           described_class.spy_on(command_class) do |spy|
             block_called = true
 
             expect(spy).to be instance_spy
-          end # spy_on
+          end
 
           expect(block_called).to be true
-        end # it
-      end # wrap_context
-    end # describe
+        end
+      end
+    end
 
     describe 'with Cuprum::Operation' do
       let(:command_class)    { Spec::ExampleOperation }
@@ -307,7 +309,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         spy = described_class.spy_on(Cuprum::Operation)
 
         expect(spy).to be_a described_class::Spy
-      end # it
+      end
 
       it 'should instrument calls to #call on a subclass' do
         spy = described_class.spy_on(Cuprum::Operation)
@@ -317,8 +319,8 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         command_instance.call(*command_arguments)
 
         expect(spy).to have_received(:call).with(*command_arguments)
-      end # it
-    end # describe
+      end
+    end
 
     describe 'with a module' do
       let(:command_class)    { Spec::ExampleOperation }
@@ -328,7 +330,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         spy = described_class.spy_on(Cuprum::Operation::Mixin)
 
         expect(spy).to be_a described_class::Spy
-      end # it
+      end
 
       it 'should instrument calls to #call' do
         spy = described_class.spy_on(Cuprum::Operation::Mixin)
@@ -338,7 +340,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
         command_instance.call(*command_arguments)
 
         expect(spy).to have_received(:call).with(*command_arguments)
-      end # it
+      end
 
       it 'should execute the command implementation' do
         allow(command_instance).to receive(:process)
@@ -347,25 +349,27 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
 
         command_instance.call(*command_arguments)
 
-        expect(command_instance).
-          to have_received(:process).
-          with(*command_arguments)
-      end # it
-    end # describe
+        expect(command_instance)
+          .to have_received(:process)
+          .with(*command_arguments)
+      end
+    end
 
     wrap_context 'when there is an instance spy on a command class' do
       describe 'with a command subclass' do
         let(:command_subclass) { Class.new(command_class) }
         let(:command_instance) { command_subclass.new }
 
-        it 'should return a spy' do
+        it 'should return a spy', :aggregate_failures do
           spy = described_class.spy_on(command_subclass)
 
           expect(spy).to be_a described_class::Spy
           expect(spy).not_to be instance_spy
-        end # it
+        end
 
-        it 'should instrument calls to #call on the subclass' do
+        it 'should instrument calls to #call on the subclass',
+          :aggregate_failures \
+        do
           spy = described_class.spy_on(command_subclass)
 
           allow(instance_spy).to receive(:call)
@@ -375,7 +379,7 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
 
           expect(instance_spy).to have_received(:call).with(*command_arguments)
           expect(spy).to have_received(:call).with(*command_arguments)
-        end # it
+        end
 
         it 'should not instrument calls in other threads' do
           allow(instance_spy).to receive(:call)
@@ -383,8 +387,8 @@ RSpec.describe Cuprum::Utils::InstanceSpy do
           Thread.new { command_instance.call(*command_arguments) }.join
 
           expect(instance_spy).not_to have_received(:call)
-        end # it
-      end # describe
-    end # wrap_context
-  end # describe
-end # describe
+        end
+      end
+    end
+  end
+end

--- a/spec/cuprum_spec.rb
+++ b/spec/cuprum_spec.rb
@@ -1,21 +1,21 @@
-# spec/cuprum_spec.rb
+# frozen_string_literal: true
 
 require 'cuprum'
 
 RSpec.describe Cuprum do
   describe '::VERSION' do
     it 'should define the constant' do
-      expect(described_class).
-        to have_constant(:VERSION).
-        with_value(Cuprum::Version.to_gem_version)
-    end # it
-  end # describe
+      expect(described_class)
+        .to have_constant(:VERSION)
+        .with_value(Cuprum::Version.to_gem_version)
+    end
+  end
 
   describe '::version' do
     it 'should define the reader' do
-      expect(described_class).
-        to have_reader(:version).
-        with_value(Cuprum::Version.to_gem_version)
-    end # it
-  end # describe
-end # describe
+      expect(described_class)
+        .to have_reader(:version)
+        .with_value(Cuprum::Version.to_gem_version)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 unless ENV['COVERAGE'] == 'false'
   require 'simplecov'
 
   SimpleCov.start
-end # unless
+end
 
 require 'rspec/sleeping_king_studios/all'
 require 'byebug'
@@ -43,7 +45,7 @@ RSpec.configure do |config|
     expectations.syntax = :expect
 
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-  end # configure expectations
+  end
 
   # rspec-mocks config goes here. You can use an alternate test double
   # library (such as bogus or mocha) by changing the `mock_with` option here.
@@ -54,7 +56,7 @@ RSpec.configure do |config|
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended.
     mocks.verify_partial_doubles = true
-  end # configure mocks
+  end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
@@ -62,4 +64,4 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
-end # configure
+end

--- a/spec/support/examples/currying_examples.rb
+++ b/spec/support/examples/currying_examples.rb
@@ -11,7 +11,7 @@ module Spec::Examples
     shared_examples 'should implement the Currying interface' do
       describe '#curry' do
         it 'should define the method' do
-          expect(instance)
+          expect(subject)
             .to respond_to(:curry)
             .with_unlimited_arguments
             .and_any_keywords
@@ -22,7 +22,7 @@ module Spec::Examples
     shared_examples 'should implement the Currying methods' do
       describe '#curry' do
         shared_examples 'should curry the command' do
-          let(:curried_command) { instance.curry(*arguments, **keywords) }
+          let(:curried_command) { subject.curry(*arguments, **keywords) }
 
           it 'should return a curried command' do
             expect(curried_command).to be_a Cuprum::Currying::CurriedCommand
@@ -33,7 +33,7 @@ module Spec::Examples
           end
 
           it 'should set the command' do
-            expect(curried_command.command).to be instance
+            expect(curried_command.command).to be subject
           end
 
           it 'should set the command' do
@@ -46,7 +46,7 @@ module Spec::Examples
 
         describe 'with no arguments or keywords' do
           it 'should return the command' do
-            expect(instance.curry).to be instance
+            expect(subject.curry).to be subject
           end
         end
 

--- a/spec/support/examples/operation_examples.rb
+++ b/spec/support/examples/operation_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/sleeping_king_studios/concerns/shared_example_group'
 
 module Spec::Examples
@@ -5,15 +7,15 @@ module Spec::Examples
     extend RSpec::SleepingKingStudios::Concerns::SharedExampleGroup
 
     shared_context 'when the operation has been called' do
-      let(:value) { 'returned value'.freeze }
+      let(:value) { 'returned value' }
 
       def call_operation
-        call_method = instance.method(:call)
+        call_method = operation.method(:call)
 
-        instance.call(*generate_arguments(call_method))
-      end # method call_operation
+        operation.call(*generate_arguments(call_method))
+      end
 
-      def generate_arguments method
+      def generate_arguments(method)
         params    = method.parameters
         count     = params.select { |(type, _)| type == :req }.count
         keys      =
@@ -22,37 +24,37 @@ module Spec::Examples
         keywords  = Hash[keys.map { |key| [key, nil] }]
 
         keywords.empty? ? arguments : arguments << keywords
-      end # method generate_arguments
+      end
 
       before(:example) do
-        allow(instance).to receive(:process).and_return(value)
-      end # before example
-    end # shared_context
+        allow(operation).to receive(:process).and_return(value)
+      end
+    end
 
     shared_context 'when the result has an error' do
-      let(:value)  { 'returned value'.freeze }
+      let(:value)  { 'returned value' }
       let(:error)  { Cuprum::Error.new(message: 'Something went wrong.') }
       let(:result) { Cuprum::Result.new(value: value, error: error) }
 
       before(:example) do
-        allow(instance).to receive(:result).and_return(result)
-      end # before example
-    end # shared_context
+        allow(operation).to receive(:result).and_return(result)
+      end
+    end
 
     shared_context 'when the result has a value' do
-      let(:value)  { 'returned value'.freeze }
+      let(:value)  { 'returned value' }
       let(:result) { Cuprum::Result.new(value: value) }
 
       before(:example) do
-        allow(instance).to receive(:result).and_return(result)
-      end # before example
-    end # shared_context
+        allow(operation).to receive(:result).and_return(result)
+      end
+    end
 
     shared_context 'when the result has status: :failure' do
       let(:result) { Cuprum::Result.new(status: :failure) }
 
       before(:example) do
-        allow(instance).to receive(:result).and_return(result)
+        allow(operation).to receive(:result).and_return(result)
       end
     end
 
@@ -60,7 +62,7 @@ module Spec::Examples
       let(:result) { Cuprum::Result.new(status: :success) }
 
       before(:example) do
-        allow(instance).to receive(:result).and_return(result)
+        allow(operation).to receive(:result).and_return(result)
       end
     end
 
@@ -68,10 +70,10 @@ module Spec::Examples
       describe '#call' do
         wrap_context 'when the operation has been called' do
           it 'should return the operation' do
-            expect(call_operation).to be instance
-          end # it
-        end # it
-      end # describe
+            expect(call_operation).to be operation
+          end
+        end
+      end
 
       describe '#called?' do
         include_examples 'should have predicate', :called?, false
@@ -79,89 +81,87 @@ module Spec::Examples
         wrap_context 'when the operation has been called' do
           before(:example) { call_operation }
 
-          it { expect(instance.called?).to be true }
-        end # wrap_context
-      end # describe
+          it { expect(operation.called?).to be true }
+        end
+      end
 
       describe '#error' do
         include_examples 'should have reader', :error, nil
 
         wrap_context 'when the result has a value' do
-          it { expect(instance.error).to be nil }
-        end # wrap_context
+          it { expect(operation.error).to be nil }
+        end
 
         wrap_context 'when the result has an error' do
-          it { expect(instance.error).to be == error }
-        end # wrap_context
-      end # describe
+          it { expect(operation.error).to be == error }
+        end
+      end
 
       describe '#failure?' do
         include_examples 'should have predicate', :failure?, false
 
         wrap_context 'when the result has a value' do
-          it { expect(instance.failure?).to be false }
-        end # wrap_context
+          it { expect(operation.failure?).to be false }
+        end
 
         wrap_context 'when the result has an error' do
-          it { expect(instance.failure?).to be true }
-        end # wrap_context
+          it { expect(operation.failure?).to be true }
+        end
 
         wrap_context 'when the result has status: :failure' do
-          it { expect(instance.failure?).to be true }
+          it { expect(operation.failure?).to be true }
         end
 
         wrap_context 'when the result has status: :success' do
-          it { expect(instance.failure?).to be false }
+          it { expect(operation.failure?).to be false }
         end
-      end # describe
+      end
 
       describe '#reset!' do
-        it { expect(instance).to respond_to(:reset!).with(0).arguments }
+        it { expect(operation).to respond_to(:reset!).with(0).arguments }
 
         wrap_context 'when the operation has been called' do
           before(:example) { call_operation }
 
           it 'should clear the result' do
-            expect { instance.reset! }.to change(instance, :result).to be nil
-          end # it
+            expect { operation.reset! }.to change(operation, :result).to be nil
+          end
 
           it 'should mark the operation as not called' do
-            expect { instance.reset! }.to change(instance, :called?).to be false
-          end # it
-        end # wrap_context
-      end # describe
+            expect { operation.reset! }
+              .to change(operation, :called?)
+              .to be false
+          end
+        end
+      end
 
       describe '#result' do
         include_examples 'should have reader', :result, nil
 
         wrap_context 'when the operation has been called' do
-          it 'should return the result' do
-            call_operation
+          it { expect(call_operation.result).to be_a Cuprum::Result }
 
-            result = instance.result
-            expect(result).to be_a Cuprum::Result
-            expect(result.value).to be value
-          end # it
-        end # wrap_context
-      end # describe
+          it { expect(call_operation.result.value).to be value }
+        end
+      end
 
       describe '#status' do
         include_examples 'should have reader', :status, nil
 
         wrap_context 'when the result has a value' do
-          it { expect(instance.status).to be :success }
+          it { expect(operation.status).to be :success }
         end
 
         wrap_context 'when the result has an error' do
-          it { expect(instance.status).to be :failure }
+          it { expect(operation.status).to be :failure }
         end
 
         wrap_context 'when the result has status: :failure' do
-          it { expect(instance.status).to be :failure }
+          it { expect(operation.status).to be :failure }
         end
 
         wrap_context 'when the result has status: :success' do
-          it { expect(instance.status).to be :success }
+          it { expect(operation.status).to be :success }
         end
       end
 
@@ -169,25 +169,25 @@ module Spec::Examples
         include_examples 'should have predicate', :success?, false
 
         wrap_context 'when the result has a value' do
-          it { expect(instance.success?).to be true }
-        end # wrap_context
+          it { expect(operation.success?).to be true }
+        end
 
         wrap_context 'when the result has an error' do
-          it { expect(instance.success?).to be false }
-        end # wrap_context
+          it { expect(operation.success?).to be false }
+        end
 
         wrap_context 'when the result has status: :failure' do
-          it { expect(instance.success?).to be false }
+          it { expect(operation.success?).to be false }
         end
 
         wrap_context 'when the result has status: :success' do
-          it { expect(instance.success?).to be true }
+          it { expect(operation.success?).to be true }
         end
-      end # describe
+      end
 
       describe '#to_cuprum_result' do
         it 'should return an OperationNotCalled error', :aggregate_failures do
-          result = instance.to_cuprum_result
+          result = operation.to_cuprum_result
           error  = result.error
 
           expect(result).to be_a Cuprum::Result
@@ -195,31 +195,27 @@ module Spec::Examples
           expect(result.value).to be nil
 
           expect(error).to be_a Cuprum::Errors::OperationNotCalled
-          expect(error.operation).to be instance
+          expect(error.operation).to be operation
         end
 
         wrap_context 'when the operation has been called' do
-          it 'should return the result' do
-            call_operation
+          it { expect(call_operation.to_cuprum_result).to be_a Cuprum::Result }
 
-            result = instance.to_cuprum_result
-            expect(result).to be_a Cuprum::Result
-            expect(result.value).to be value
-          end # it
-        end # wrap_context
-      end # describe
+          it { expect(call_operation.to_cuprum_result.value).to be value }
+        end
+      end
 
       describe '#value' do
         include_examples 'should have reader', :value, nil
 
         wrap_context 'when the result has a value' do
-          it { expect(instance.value).to be value }
-        end # wrap_context
+          it { expect(operation.value).to be value }
+        end
 
         wrap_context 'when the result has an error' do
-          it { expect(instance.value).to be value }
-        end # wrap_context
-      end # describe
-    end # shared_examples
-  end # module
-end # module
+          it { expect(operation.value).to be value }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/examples/result_examples.rb
+++ b/spec/support/examples/result_examples.rb
@@ -25,21 +25,21 @@ module Spec::Examples
         let(:other_value)  { kwargs.fetch(:value) }
         let(:other_error)  { kwargs.fetch(:error) }
         let(:other_status) { kwargs.fetch(:status) }
-        let(:result) do
+        let(:other_result) do
           described_class.new(
             value:  other_value,
             error:  other_error,
             status: other_status
           )
         end
-        let(:other) { defined?(super()) ? super() : result }
+        let(:other) { defined?(super()) ? super() : other_result }
         let(:expected) do
           %i[error status value]
-            .map { |method| instance.send(method) == other.send(method) }
+            .map { |method| result.send(method) == other.send(method) }
             .reduce(true) { |memo, bool| memo && bool }
         end
 
-        it { expect(instance == other).to be expected }
+        it { expect(result == other).to be expected }
       end
 
       shared_examples 'should compare the results in each scenario' \

--- a/spec/support/examples/result_helpers_examples.rb
+++ b/spec/support/examples/result_helpers_examples.rb
@@ -11,7 +11,7 @@ module Spec::Examples
     shared_examples 'should implement the ResultHelpers interface' do
       describe '#build_result' do
         it 'should define the method' do
-          expect(instance)
+          expect(subject)
             .to respond_to(:build_result, true)
             .with(0).arguments
             .and_keywords(:error, :status, :value)
@@ -20,13 +20,13 @@ module Spec::Examples
 
       describe '#failure' do
         it 'should define the method' do
-          expect(instance).to respond_to(:failure, true).with(1).argument
+          expect(subject).to respond_to(:failure, true).with(1).argument
         end
       end
 
       describe '#success' do
         it 'should define the method' do
-          expect(instance).to respond_to(:success, true).with(1).argument
+          expect(subject).to respond_to(:success, true).with(1).argument
         end
       end
     end
@@ -36,17 +36,17 @@ module Spec::Examples
         let(:value) { 'returned value' }
         let(:error) { Cuprum::Error.new(message: 'Something went wrong.') }
 
-        it 'should define the private method' do
-          expect(instance).not_to respond_to(:build_result)
+        it { expect(subject).not_to respond_to(:build_result) }
 
-          expect(instance)
+        it 'should define the private method' do
+          expect(subject)
             .to respond_to(:build_result, true)
             .with(0).arguments
             .and_keywords(:error, :status, :value)
         end
 
         describe 'with no keywords' do
-          let(:result) { instance.send(:build_result) }
+          let(:result) { subject.send(:build_result) }
 
           it { expect(result).to be_a Cuprum::Result }
 
@@ -57,15 +57,15 @@ module Spec::Examples
           it { expect(result.value).to be nil }
 
           it 'should return a new object each time it is called' do
-            result = instance.send(:build_result)
+            result = subject.send(:build_result)
 
-            expect(instance.send :build_result)
+            expect(subject.send :build_result)
               .not_to be result
           end
         end
 
         describe 'with error: an error' do
-          let(:result) { instance.send(:build_result, error: error) }
+          let(:result) { subject.send(:build_result, error: error) }
 
           it { expect(result).to be_a Cuprum::Result }
 
@@ -76,16 +76,16 @@ module Spec::Examples
           it { expect(result.value).to be nil }
 
           it 'should return a new object each time it is called' do
-            result = instance.send(:build_result, error: error)
+            result = subject.send(:build_result, error: error)
 
-            expect(instance.send :build_result, error: error)
+            expect(subject.send :build_result, error: error)
               .not_to be result
           end
         end
 
         describe 'with error: an error and status: :failure' do
           let(:result) do
-            instance.send(:build_result, error: error, status: :failure)
+            subject.send(:build_result, error: error, status: :failure)
           end
 
           it { expect(result).to be_a Cuprum::Result }
@@ -98,16 +98,16 @@ module Spec::Examples
 
           it 'should return a new object each time it is called' do
             result =
-              instance.send(:build_result, error: error, status: :failure)
+              subject.send(:build_result, error: error, status: :failure)
 
-            expect(instance.send :build_result, error: error, status: :failure)
+            expect(subject.send :build_result, error: error, status: :failure)
               .not_to be result
           end
         end
 
         describe 'with error: an error and status: :success' do
           let(:result) do
-            instance.send(:build_result, error: error, status: :success)
+            subject.send(:build_result, error: error, status: :success)
           end
 
           it { expect(result).to be_a Cuprum::Result }
@@ -120,16 +120,16 @@ module Spec::Examples
 
           it 'should return a new object each time it is called' do
             result =
-              instance.send(:build_result, error: error, status: :success)
+              subject.send(:build_result, error: error, status: :success)
 
-            expect(instance.send :build_result, error: error, status: :success)
+            expect(subject.send :build_result, error: error, status: :success)
               .not_to be result
           end
         end
 
         describe 'with error: an error and value: a value' do
           let(:result) do
-            instance.send(:build_result, error: error, value: value)
+            subject.send(:build_result, error: error, value: value)
           end
 
           it { expect(result).to be_a Cuprum::Result }
@@ -142,15 +142,15 @@ module Spec::Examples
 
           it 'should return a new object each time it is called' do
             result =
-              instance.send(:build_result, error: error, value: value)
+              subject.send(:build_result, error: error, value: value)
 
-            expect(instance.send :build_result, error: error, value: value)
+            expect(subject.send :build_result, error: error, value: value)
               .not_to be result
           end
         end
 
         describe 'with status: :failure' do
-          let(:result) { instance.send(:build_result, status: :failure) }
+          let(:result) { subject.send(:build_result, status: :failure) }
 
           it { expect(result).to be_a Cuprum::Result }
 
@@ -161,16 +161,16 @@ module Spec::Examples
           it { expect(result.value).to be nil }
 
           it 'should return a new object each time it is called' do
-            result = instance.send(:build_result, status: :failure)
+            result = subject.send(:build_result, status: :failure)
 
-            expect(instance.send :build_result, status: :failure)
+            expect(subject.send :build_result, status: :failure)
               .not_to be result
           end
         end
 
         describe 'with status: :failure and value: a value' do
           let(:result) do
-            instance.send(:build_result, status: :failure, value: value)
+            subject.send(:build_result, status: :failure, value: value)
           end
 
           it { expect(result).to be_a Cuprum::Result }
@@ -183,15 +183,15 @@ module Spec::Examples
 
           it 'should return a new object each time it is called' do
             result =
-              instance.send(:build_result, status: :failure, value: value)
+              subject.send(:build_result, status: :failure, value: value)
 
-            expect(instance.send :build_result, status: :failure, value: value)
+            expect(subject.send :build_result, status: :failure, value: value)
               .not_to be result
           end
         end
 
         describe 'with status: :success' do
-          let(:result) { instance.send(:build_result, status: :success) }
+          let(:result) { subject.send(:build_result, status: :success) }
 
           it { expect(result).to be_a Cuprum::Result }
 
@@ -202,16 +202,16 @@ module Spec::Examples
           it { expect(result.value).to be nil }
 
           it 'should return a new object each time it is called' do
-            result = instance.send(:build_result, status: :success)
+            result = subject.send(:build_result, status: :success)
 
-            expect(instance.send :build_result, status: :success)
+            expect(subject.send :build_result, status: :success)
               .not_to be result
           end
         end
 
         describe 'with status: :success and value: a value' do
           let(:result) do
-            instance.send(:build_result, status: :success, value: value)
+            subject.send(:build_result, status: :success, value: value)
           end
 
           it { expect(result).to be_a Cuprum::Result }
@@ -224,15 +224,15 @@ module Spec::Examples
 
           it 'should return a new object each time it is called' do
             result =
-              instance.send(:build_result, status: :success, value: value)
+              subject.send(:build_result, status: :success, value: value)
 
-            expect(instance.send :build_result, status: :success, value: value)
+            expect(subject.send :build_result, status: :success, value: value)
               .not_to be result
           end
         end
 
         describe 'with value: a value' do
-          let(:result) { instance.send(:build_result, value: value) }
+          let(:result) { subject.send(:build_result, value: value) }
 
           it { expect(result).to be_a Cuprum::Result }
 
@@ -243,16 +243,16 @@ module Spec::Examples
           it { expect(result.value).to be value }
 
           it 'should return a new object each time it is called' do
-            result = instance.send(:build_result, value: value)
+            result = subject.send(:build_result, value: value)
 
-            expect(instance.send :build_result, value: value)
+            expect(subject.send :build_result, value: value)
               .not_to be result
           end
         end
 
         describe 'with an error, status: :failure, and a value' do
           let(:result) do
-            instance.send(
+            subject.send(
               :build_result,
               error:  error,
               status: :failure,
@@ -270,16 +270,16 @@ module Spec::Examples
 
           it 'should return a new object each time it is called' do
             result =
-              instance.send(:build_result, status: :failure, value: value)
+              subject.send(:build_result, status: :failure, value: value)
 
-            expect(instance.send :build_result, status: :failure, value: value)
+            expect(subject.send :build_result, status: :failure, value: value)
               .not_to be result
           end
         end
 
         describe 'with an error, status: :success, and a value' do
           let(:result) do
-            instance.send(
+            subject.send(
               :build_result,
               error:  error,
               status: :success,
@@ -297,9 +297,9 @@ module Spec::Examples
 
           it 'should return a new object each time it is called' do
             result =
-              instance.send(:build_result, status: :success, value: value)
+              subject.send(:build_result, status: :success, value: value)
 
-            expect(instance.send :build_result, status: :success, value: value)
+            expect(subject.send :build_result, status: :success, value: value)
               .not_to be result
           end
         end
@@ -308,22 +308,22 @@ module Spec::Examples
       describe '#failure' do
         let(:error) { Cuprum::Error.new(message: 'Something went wrong.') }
 
-        it 'should define the private method' do
-          expect(instance).not_to respond_to(:failure)
+        it { expect(subject).not_to respond_to(:failure) }
 
-          expect(instance).to respond_to(:failure, true).with(1).argument
+        it 'should define the private method' do
+          expect(subject).to respond_to(:failure, true).with(1).argument
         end
 
         it 'should delegate to #build_result' do
-          allow(instance).to receive(:build_result)
+          allow(subject).to receive(:build_result)
 
-          instance.send(:failure, error)
+          subject.send(:failure, error)
 
-          expect(instance).to have_received(:build_result).with(error: error)
+          expect(subject).to have_received(:build_result).with(error: error)
         end
 
         it 'should return a failing result', :aggregate_failures do
-          result = instance.send(:failure, error)
+          result = subject.send(:failure, error)
 
           expect(result).to be_a Cuprum::Result
           expect(result.status).to be :failure
@@ -335,22 +335,22 @@ module Spec::Examples
       describe '#success' do
         let(:value) { 'result value' }
 
-        it 'should define the private method' do
-          expect(instance).not_to respond_to(:success)
+        it { expect(subject).not_to respond_to(:success) }
 
-          expect(instance).to respond_to(:success, true).with(1).argument
+        it 'should define the private method' do
+          expect(subject).to respond_to(:success, true).with(1).argument
         end
 
         it 'should delegate to #build_result' do
-          allow(instance).to receive(:build_result)
+          allow(subject).to receive(:build_result)
 
-          instance.send(:success, value)
+          subject.send(:success, value)
 
-          expect(instance).to have_received(:build_result).with(value: value)
+          expect(subject).to have_received(:build_result).with(value: value)
         end
 
         it 'should return a passing result', :aggregate_failures do
-          result = instance.send(:success, value)
+          result = subject.send(:success, value)
 
           expect(result).to be_a Cuprum::Result
           expect(result.status).to be :success

--- a/spec/support/examples/steps_examples.rb
+++ b/spec/support/examples/steps_examples.rb
@@ -13,7 +13,7 @@ module Spec::Examples
     shared_examples 'should implement the Steps interface' do
       describe '#step' do
         it 'should define the method' do
-          expect(instance)
+          expect(subject)
             .to respond_to(:step)
             .with(0..1).arguments
             .and_unlimited_arguments
@@ -23,7 +23,7 @@ module Spec::Examples
       end
 
       describe '#steps' do
-        it { expect(instance).to respond_to(:steps).with(0).arguments }
+        it { expect(subject).to respond_to(:steps).with(0).arguments }
       end
     end
 
@@ -66,7 +66,7 @@ module Spec::Examples
           let(:error_message) { 'expected a block or a method name' }
 
           it 'should raise an exception' do
-            expect { instance.step }
+            expect { subject.step }
               .to raise_error ArgumentError, error_message
           end
         end
@@ -75,11 +75,11 @@ module Spec::Examples
           let(:block) { -> { returned_value } }
 
           def call_step
-            instance.step(&block)
+            subject.step(&block)
           end
 
           it 'should call the block' do
-            expect { |block| instance.step(&block) }.to yield_control
+            expect { |block| subject.step(&block) }.to yield_control
           end
 
           include_examples 'should wrap the returned value'
@@ -89,7 +89,7 @@ module Spec::Examples
           let(:error_message) { 'expected a block or a method name' }
 
           it 'should raise an exception' do
-            expect { instance.step(nil) }
+            expect { subject.step(nil) }
               .to raise_error ArgumentError, error_message
           end
         end
@@ -100,7 +100,7 @@ module Spec::Examples
           end
 
           it 'should raise an exception' do
-            expect { instance.step(Object.new.freeze) }
+            expect { subject.step(Object.new.freeze) }
               .to raise_error ArgumentError, error_message
           end
         end
@@ -109,7 +109,7 @@ module Spec::Examples
           let(:error_message) { "method name can't be blank" }
 
           it 'should raise an exception' do
-            expect { instance.step('') }
+            expect { subject.step('') }
               .to raise_error ArgumentError, error_message
           end
         end
@@ -118,19 +118,19 @@ module Spec::Examples
           let(:method_name) { :custom_method }
 
           def call_step
-            instance.step(method_name)
+            subject.step(method_name)
           end
 
           before(:example) do
-            instance.singleton_class.send(:define_method, method_name) {}
+            subject.singleton_class.send(:define_method, method_name) { nil }
 
-            allow(instance).to receive(method_name).and_return(returned_value)
+            allow(subject).to receive(method_name).and_return(returned_value)
           end
 
           it 'should call the method' do
-            instance.step(method_name)
+            subject.step(method_name)
 
-            expect(instance).to have_received(method_name).with(no_args)
+            expect(subject).to have_received(method_name).with(no_args)
           end
 
           include_examples 'should wrap the returned value'
@@ -141,19 +141,23 @@ module Spec::Examples
           let(:method_args) { %w[ichi ni san] }
 
           before(:example) do
-            instance.singleton_class.send(:define_method, method_name) { |*_| }
+            # :nocov:
+            subject
+              .singleton_class
+              .send(:define_method, method_name) { |*_| nil }
+            # :nocov:
 
-            allow(instance).to receive(method_name).and_return(returned_value)
+            allow(subject).to receive(method_name).and_return(returned_value)
           end
 
           def call_step
-            instance.step(method_name, *method_args)
+            subject.step(method_name, *method_args)
           end
 
           it 'should call the method' do
-            instance.step(method_name, *method_args)
+            subject.step(method_name, *method_args)
 
-            expect(instance).to have_received(method_name).with(*method_args)
+            expect(subject).to have_received(method_name).with(*method_args)
           end
 
           include_examples 'should wrap the returned value'
@@ -164,19 +168,23 @@ module Spec::Examples
           let(:method_kwargs) { { uno: 1, dos: 2, tres: 3 } }
 
           before(:example) do
-            instance.singleton_class.send(:define_method, method_name) { |**_| }
+            # :nocov:
+            subject
+              .singleton_class
+              .send(:define_method, method_name) { |**_| nil }
+            # :nocov:
 
-            allow(instance).to receive(method_name).and_return(returned_value)
+            allow(subject).to receive(method_name).and_return(returned_value)
           end
 
           def call_step
-            instance.step(method_name, **method_kwargs)
+            subject.step(method_name, **method_kwargs)
           end
 
           it 'should call the method' do
-            instance.step(method_name, **method_kwargs)
+            subject.step(method_name, **method_kwargs)
 
-            expect(instance).to have_received(method_name).with(**method_kwargs)
+            expect(subject).to have_received(method_name).with(**method_kwargs)
           end
 
           include_examples 'should wrap the returned value'
@@ -187,9 +195,9 @@ module Spec::Examples
           let(:method_block) { -> {} }
 
           before(:example) do
-            instance.singleton_class.send(:define_method, method_name) {}
+            subject.singleton_class.send(:define_method, method_name) { nil }
 
-            allow(instance).to receive(method_name) do |&block|
+            allow(subject).to receive(method_name) do |&block|
               block.call
 
               returned_value
@@ -197,17 +205,17 @@ module Spec::Examples
           end
 
           def call_step
-            instance.step(method_name, &method_block)
+            subject.step(method_name, &method_block)
           end
 
           it 'should call the method' do
-            instance.step(method_name, &method_block)
+            subject.step(method_name, &method_block)
 
-            expect(instance).to have_received(method_name).with(no_args)
+            expect(subject).to have_received(method_name).with(no_args)
           end
 
           it 'should yield the block' do
-            expect { |block| instance.step(method_name, &block) }
+            expect { |block| subject.step(method_name, &block) }
               .to yield_control
           end
 
@@ -221,10 +229,13 @@ module Spec::Examples
           let(:method_block)  { -> {} }
 
           before(:example) do
-            instance.singleton_class.send(:define_method, method_name) \
-            { |*_, **_, &block| }
+            # :nocov:
+            subject
+              .singleton_class
+              .send(:define_method, method_name) { |*_, **_, &_block| nil }
+            # :nocov:
 
-            allow(instance).to receive(method_name) do |*_, &block|
+            allow(subject).to receive(method_name) do |*_, &block|
               block.call
 
               returned_value
@@ -232,7 +243,7 @@ module Spec::Examples
           end
 
           def call_step(&block)
-            instance.step(
+            subject.step(
               method_name,
               *method_args,
               **method_kwargs,
@@ -243,7 +254,7 @@ module Spec::Examples
           it 'should call the method' do
             call_step
 
-            expect(instance)
+            expect(subject)
               .to have_received(method_name)
               .with(*method_args, **method_kwargs)
           end
@@ -259,17 +270,18 @@ module Spec::Examples
 
       describe '#steps' do
         describe 'without a block' do
-          let(:error_message) { 'no block given (yield)' }
+          let(:error_message) { 'no block given' }
 
           it 'should raise an exception' do
-            expect { instance.steps }
-              .to raise_error LocalJumpError, error_message
+            expect { subject.steps }
+              .to raise_error ArgumentError, error_message
           end
         end
 
         describe 'with an empty block' do
           it 'should return a passing result' do
-            expect(instance.steps {}).to be_a_passing_result.with_value(nil)
+            expect(subject.steps { nil })
+              .to be_a_passing_result.with_value(nil)
           end
         end
 
@@ -277,7 +289,7 @@ module Spec::Examples
           let(:returned_value) { Object.new.freeze }
 
           it 'should return a passing result' do
-            expect(instance.steps { returned_value })
+            expect(subject.steps { returned_value })
               .to be_a_passing_result
               .with_value(returned_value)
           end
@@ -287,7 +299,7 @@ module Spec::Examples
           let(:returned_result) { Cuprum::Result.new(status: :failure) }
 
           it 'should return the result' do
-            expect(instance.steps { returned_result }).to be returned_result
+            expect(subject.steps { returned_result }).to be returned_result
           end
         end
 
@@ -295,7 +307,7 @@ module Spec::Examples
           let(:returned_result) { Cuprum::Result.new(status: :success) }
 
           it 'should return the result' do
-            expect(instance.steps { returned_result }).to be returned_result
+            expect(subject.steps { returned_result }).to be returned_result
           end
         end
 
@@ -303,7 +315,7 @@ module Spec::Examples
           let(:error_message) { 'something went wrong' }
 
           it 'should raise the exception' do
-            expect { instance.steps { raise error_message } }
+            expect { subject.steps { raise error_message } }
               .to raise_error StandardError, error_message
           end
         end
@@ -313,7 +325,7 @@ module Spec::Examples
           let(:thrown_value)  { Object.new.freeze }
 
           it 'should throw the symbol' do
-            expect { instance.steps { throw thrown_symbol, thrown_value } }
+            expect { subject.steps { throw thrown_symbol, thrown_value } }
               .to throw_symbol(thrown_symbol, thrown_value)
           end
         end
@@ -323,7 +335,7 @@ module Spec::Examples
           let(:thrown_result) { Cuprum::Result.new(status: :failure) }
 
           it 'should return the failing result' do
-            expect(instance.steps { throw thrown_symbol, thrown_result })
+            expect(subject.steps { throw thrown_symbol, thrown_result })
               .to be thrown_result
           end
         end

--- a/spec/support/matrix_spec.rb
+++ b/spec/support/matrix_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       let(:scenarios) { {} }
 
       it 'should not define an example group' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).not_to have_received(:context)
       end
@@ -53,7 +53,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       end
 
       it 'should define one example group' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).to have_received(:context).exactly(1).times
       end
@@ -87,7 +87,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       end
 
       it 'should define three example groups' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).to have_received(:context).exactly(3).times
       end
@@ -115,7 +115,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       end
 
       it 'should define each example group' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).to have_received(:context).exactly(1).times
       end
@@ -161,7 +161,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       end
 
       it 'should define each example group' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).to have_received(:context).exactly(9).times
       end
@@ -192,7 +192,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       end
 
       it 'should define one example group' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).to have_received(:context).exactly(1).times
       end
@@ -211,12 +211,12 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
     describe 'with many scenarios with many values each' do
       let(:scenarios) do
         {
-          english: {
+          english:  {
             'one'   => 1,
             'two'   => 2,
             'three' => 3
           },
-          spanish: {
+          spanish:  {
             'uno'  => 1,
             'dos'  => 2,
             'tres' => 3
@@ -230,7 +230,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       end
 
       it 'should define each example group' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).to have_received(:context).exactly(27).times
       end
@@ -239,7 +239,7 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
     describe 'with a scenario with an empty label' do
       let(:scenarios) do
         {
-          english: {
+          english:    {
             'one'   => 1,
             'two'   => 2,
             'three' => 3
@@ -253,29 +253,47 @@ RSpec.describe Spec::Matrix do # rubocop:disable RSpec/FilePath
       end
       let(:expected) do
         {
-          'with one' =>
-            { english: 1, capitalize: nil },
-          'with one and capitalize: false' =>
-            { english: 1, capitalize: false },
-          'with one and capitalize: true' =>
-            { english: 1, capitalize: true },
-          'with two' =>
-            { english: 2, capitalize: nil },
-          'with two and capitalize: false' =>
-            { english: 2, capitalize: false },
-          'with two and capitalize: true' =>
-            { english: 2, capitalize: true },
-          'with three' =>
-            { english: 3, capitalize: nil },
-          'with three and capitalize: false' =>
-            { english: 3, capitalize: false },
-          'with three and capitalize: true' =>
-            { english: 3, capitalize: true }
+          'with one'                         => {
+            english:    1,
+            capitalize: nil
+          },
+          'with one and capitalize: false'   => {
+            english:    1,
+            capitalize: false
+          },
+          'with one and capitalize: true'    => {
+            english:    1,
+            capitalize: true
+          },
+          'with two'                         => {
+            english:    2,
+            capitalize: nil
+          },
+          'with two and capitalize: false'   => {
+            english:    2,
+            capitalize: false
+          },
+          'with two and capitalize: true'    => {
+            english:    2,
+            capitalize: true
+          },
+          'with three'                       => {
+            english:    3,
+            capitalize: nil
+          },
+          'with three and capitalize: false' => {
+            english:    3,
+            capitalize: false
+          },
+          'with three and capitalize: true'  => {
+            english:    3,
+            capitalize: true
+          }
         }
       end
 
       it 'should define each example group' do
-        matrix.evaluate(**scenarios) {}
+        matrix.evaluate(**scenarios) { nil }
 
         expect(example_group).to have_received(:context).exactly(9).times
       end


### PR DESCRIPTION
- Replace subject(:instance) pattern in specs.
- Update RuboCop to 1.6.