### PR TITLE
Chore/Update tools dependency to require 1.0.0 release.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,11 +21,9 @@ Steps Case Study: |
   Tags.each { FindOrCreate Tag }
   Publish Post # Requires that post have content
 
-### Commands
-
-- Implement `Command#to_proc`.
-
 ## Future Versions
+
+Add `.rbs` files
 
 ### Commands
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'sleeping_king_studios-tasks',
-  git: 'https://github.com/sleepingkingstudios/sleeping_king_studios-tasks'
+gem 'rspec-sleeping_king_studios',
+  git: 'https://github.com/sleepingkingstudios/rspec-sleeping_king_studios'
+
+gem 'sleeping_king_studios-tasks', '~> 0.4', '>= 0.4.1'
 
 group :development, :test do
   gem 'byebug', '~> 9.0', '>= 9.0.6'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Traditional frameworks such as Rails focus on the objects of your application - 
 - **Consistency:** Use the same Commands to underlie controller actions, worker processes and test factories.
 - **Encapsulation:** Each Command is defined and run in isolation, and dependencies must be explicitly provided to the command when it is initialized or run. This makes it easier to reason about the command's behavior and keep it insulated from changes elsewhere in the code.
 - **Testability:** Because the logic is extracted from unnecessary context, testing its behavior is much cleaner and easier.
-- **Composability:** Complex logic such as "find the object with this ID, update it with these attributes, and log the transaction to the reporting service" can be extracted into a series of simple Commands and composed together. The [Chaining](#label-Chaining+Commands) feature allows for complex control flows.
+- **Composability:** Complex logic such as "find the object with this ID, update it with these attributes, and log the transaction to the reporting service" can be extracted into a series of simple Commands and composed together. The [step](#label-Command+Steps) feature allows for complex control flows.
 - **Reusability:** Logic common to multiple data models or instances in your code, such as "persist an object to the database" or "find all records with a given user and created in a date range" can be refactored into parameterized commands.
 
 ### Alternatives

--- a/cuprum.gemspec
+++ b/cuprum.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.require_path = 'lib'
   gem.files        = Dir['lib/**/*.rb', 'LICENSE', '*.md']
 
-  gem.add_runtime_dependency 'sleeping_king_studios-tools', '~> 0.8'
+  gem.add_runtime_dependency 'sleeping_king_studios-tools', '~> 1.0'
 
   gem.add_development_dependency 'rspec',                       '~> 3.10'
   gem.add_development_dependency 'rspec-sleeping_king_studios', '~> 2.5'

--- a/lib/cuprum/command.rb
+++ b/lib/cuprum/command.rb
@@ -64,53 +64,6 @@ module Cuprum
   #   result.error #=> 'errors.messages.divide_by_zero'
   #   result.value #=> nil
   #
-  # @example Command Chaining
-  #   class AddCommand < Cuprum::Command
-  #     def initialize addend
-  #       @addend = addend
-  #     end
-  #
-  #     private
-  #
-  #     def process int
-  #       int + @addend
-  #     end
-  #   end
-  #
-  #   double_and_add_one = MultiplyCommand.new(2).chain(AddCommand.new(1))
-  #   result             = double_and_add_one(5)
-  #
-  #   result.value #=> 5
-  #
-  # @example Conditional Chaining
-  #   class EvenCommand < Cuprum::Command
-  #     private
-  #
-  #     def process int
-  #       return int if int.even?
-  #
-  #       Cuprum::Errors.new(error: 'errors.messages.not_even')
-  #     end
-  #   end
-  #
-  #   # The next step in a Collatz sequence is determined as follows:
-  #   # - If the number is even, divide it by 2.
-  #   # - If the number is odd, multiply it by 3 and add 1.
-  #   collatz_command =
-  #     EvenCommand.new.
-  #       chain(DivideCommand.new(2), :on => :success).
-  #       chain(
-  #         MultiplyCommand.new(3).chain(AddCommand.new(1),
-  #         :on => :failure
-  #       )
-  #
-  #   result = collatz_command.new(5)
-  #   result.value #=> 16
-  #
-  #   result = collatz_command.new(16)
-  #   result.value #=> 8
-  #
-  # @see Cuprum::Chaining
   # @see Cuprum::Processing
   class Command
     include Cuprum::Processing


### PR DESCRIPTION
- Remove deprecated Chaining references in documentation.